### PR TITLE
Adding iOS background download/upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A project committed to making file access and data transfer easier and more effi
  * [Multipart/form upload](#multipartform-data-example-post-form-data-with-file-and-data)
  * [Upload/Download progress](#user-content-uploaddownload-progress)
  * [Cancel HTTP request](#user-content-cancel-request)
+ * [iOS Background Downloading/Uploading](#ios-background-transfer-support)
  * [Android Media Scanner, and Download Manager Support](#user-content-android-media-scanner-and-download-manager-support)
  * [Self-Signed SSL Server](#user-content-self-signed-ssl-server)
  * [Transfer Encoding](#user-content-transfer-encoding)
@@ -472,7 +473,7 @@ If you have existing code that uses `whatwg-fetch`(the official **fetch**), it's
 
 [See document and examples](https://github.com/wkh237/react-native-fetch-blob/wiki/Fetch-API#fetch-replacement)
 
-### iOS Background Downloading
+### iOS Background Downloading/Uploading
 
 Normally, iOS interrupts network connections when an app is moved to the background, and will throw an error 'Lost connection to background transfer service' when the app resumes. To continue the upload or download of large files even when the app is in the background, you will need to enable IOSDownloadTask or IOSUploadTask options. The following example shows how to download a file in the background - uploading is similar except for using the IOSUploadTask config option instead.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A project committed to making file access and data transfer easier and more effi
  * [Multipart/form upload](#multipartform-data-example-post-form-data-with-file-and-data)
  * [Upload/Download progress](#user-content-uploaddownload-progress)
  * [Cancel HTTP request](#user-content-cancel-request)
- * [iOS Background Downloading/Uploading](#user-content-ios-background-downloading-uploading)
+ * [iOS Background Downloading/Uploading](#user-content-ios-background-downloadinguploading)
  * [Android Media Scanner, and Download Manager Support](#user-content-android-media-scanner-and-download-manager-support)
  * [Self-Signed SSL Server](#user-content-self-signed-ssl-server)
  * [Transfer Encoding](#user-content-transfer-encoding)

--- a/README.md
+++ b/README.md
@@ -472,6 +472,28 @@ If you have existing code that uses `whatwg-fetch`(the official **fetch**), it's
 
 [See document and examples](https://github.com/wkh237/react-native-fetch-blob/wiki/Fetch-API#fetch-replacement)
 
+### iOS Background Downloading
+
+Normally, iOS interrupts network connections when an app is moved to the background, and will throw an error 'Lost connection to background transfer service' when the app resumes. To continue the upload or download of large files even when the app is in the background, you will need to enable IOSDownloadTask or IOSUploadTask options. The following example shows how to download a file in the background - uploading is similar except for using the IOSUploadTask config option instead.
+
+```js
+
+RNFetchBlob
+    .config({
+        IOSBackgroundTask: true, // required for both upload and download
+        IOSDownloadTask: true, // For downloading in the background
+        // IOSUploadTask: true, // Use instead of IOSDownloadTask if uploading
+        path : dirs.DocumentDir + '/music.mp3'
+    })
+    .fetch('GET', 'http://example.com/music.mp3')
+    .progress((received, total) => {
+        console.log(`Received ${received} of ${total}`);
+    })
+    .catch((err) => {
+        // transfer error
+    })
+```
+
 ### Android Media Scanner, and Download Manager Support
 
 If you want to make a file in `External Storage` becomes visible in Picture, Downloads, or other built-in apps, you will have to use `Media Scanner` or `Download Manager`.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A project committed to making file access and data transfer easier and more effi
  * [Multipart/form upload](#multipartform-data-example-post-form-data-with-file-and-data)
  * [Upload/Download progress](#user-content-uploaddownload-progress)
  * [Cancel HTTP request](#user-content-cancel-request)
- * [iOS Background Downloading/Uploading](#ios-background-transfer-support)
+ * [iOS Background Downloading/Uploading](#user-content-ios-background-transfer-support)
  * [Android Media Scanner, and Download Manager Support](#user-content-android-media-scanner-and-download-manager-support)
  * [Self-Signed SSL Server](#user-content-self-signed-ssl-server)
  * [Transfer Encoding](#user-content-transfer-encoding)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A project committed to making file access and data transfer easier and more effi
  * [Multipart/form upload](#multipartform-data-example-post-form-data-with-file-and-data)
  * [Upload/Download progress](#user-content-uploaddownload-progress)
  * [Cancel HTTP request](#user-content-cancel-request)
- * [iOS Background Downloading/Uploading](#user-content-ios-background-transfer-support)
+ * [iOS Background Downloading/Uploading](#user-content-ios-background-downloading-uploading)
  * [Android Media Scanner, and Download Manager Support](#user-content-android-media-scanner-and-download-manager-support)
  * [Self-Signed SSL Server](#user-content-self-signed-ssl-server)
  * [Transfer Encoding](#user-content-transfer-encoding)

--- a/ios/RNFetchBlobNetwork.h
+++ b/ios/RNFetchBlobNetwork.h
@@ -37,8 +37,9 @@ typedef void(^DataTaskCompletionHander) (NSData * _Nullable resp, NSURLResponse 
 @property (nullable, nonatomic) RNFetchBlobFS * fileStream;
 @property (strong, nonatomic) CompletionHander fileTaskCompletionHandler;
 @property (strong, nonatomic) DataTaskCompletionHander dataTaskCompletionHandler;
-@property (nullable, nonatomic) NSError * error;
 
+@property (nullable, nonatomic) NSError * error;
+@property (nonatomic, strong) __block NSURLSession * session;
 
 + (NSMutableDictionary  * _Nullable ) normalizeHeaders:(NSDictionary * _Nullable)headers;
 + (void) cancelRequest:(NSString *)taskId;

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -16,7 +16,7 @@
 #import "IOS7Polyfill.h"
 #import <CommonCrypto/CommonDigest.h>
 #import "RNFetchBlobProgress.h"
-#import "AppDelegate.h"
+// #import "AppDelegate.h"
 #if __has_include(<React/RCTAssert.h>)
 #import <React/RCTRootView.h>
 #import <React/RCTLog.h>
@@ -528,8 +528,8 @@ totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
              sendDeviceEventWithName:EVENT_PROGRESS
              body:@{
                     @"taskId": taskId,
-                    @"written": [NSString stringWithFormat:@"%d", bytesWritten],
-                    @"total": [NSString stringWithFormat:@"%d", totalBytesWritten]
+                    @"written": [NSString stringWithFormat:@"%d", totalBytesWritten],
+                    @"total": [NSString stringWithFormat:@"%d", totalBytesExpectedToWrite]
                     }
              ];
         }
@@ -607,6 +607,7 @@ didFinishDownloadingToURL:(NSURL *)location {
 
 #pragma mark - URLSessionDidFinishEventsForBackgroundURLSession
 
+/* XXX TODO not entirely sure how to fix AppDelegate reference without hardcoding project in header paths.
 - (void) URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session
 {
     NSLog(@"sess done in background");
@@ -634,10 +635,9 @@ didFinishDownloadingToURL:(NSURL *)location {
                 }];
             }
         }
-    }];
-    
-    
+    }];   
 }
+*/
 
 
    #pragma mark - Complete and Error callback

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -16,7 +16,7 @@
 #import "IOS7Polyfill.h"
 #import <CommonCrypto/CommonDigest.h>
 #import "RNFetchBlobProgress.h"
-
+#import "AppDelegate.h"
 #if __has_include(<React/RCTAssert.h>)
 #import <React/RCTRootView.h>
 #import <React/RCTLog.h>
@@ -83,6 +83,8 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
     ResponseFormat responseFormat;
     BOOL * followRedirect;
     BOOL backgroundTask;
+    BOOL uploadTask;
+    BOOL downloadTask;
 }
 
 @end
@@ -171,6 +173,13 @@ NSOperationQueue *taskQueue;
     self.options = options;
     
     backgroundTask = [options valueForKey:@"IOSBackgroundTask"] == nil ? NO : [[options valueForKey:@"IOSBackgroundTask"] boolValue];
+    
+     downloadTask = [options valueForKey:@"IOSDownloadTask"] == nil ? NO : [[options valueForKey:@"IOSDownloadTask"] boolValue];
+    
+     uploadTask = [options valueForKey:@"IOSUploadTask"] == nil ? NO : [[options valueForKey:@"IOSUploadTask"] boolValue];
+    
+    NSString * filepath = [options valueForKey:@"uploadFilePath"];
+    
     followRedirect = [options valueForKey:@"followRedirect"] == nil ? YES : [[options valueForKey:@"followRedirect"] boolValue];
     isIncrement = [options valueForKey:@"increment"] == nil ? NO : [[options valueForKey:@"increment"] boolValue];
     redirects = [[NSMutableArray alloc] init];
@@ -189,7 +198,7 @@ NSOperationQueue *taskQueue;
     NSString * path = [self.options valueForKey:CONFIG_FILE_PATH];
     NSString * ext = [self.options valueForKey:CONFIG_FILE_EXT];
 	NSString * key = [self.options valueForKey:CONFIG_KEY];
-    __block NSURLSession * session;
+   // __block NSURLSession * session;
 
     bodyLength = contentLength;
 
@@ -210,7 +219,9 @@ NSOperationQueue *taskQueue;
         defaultConfigObject.timeoutIntervalForRequest = timeout/1000;
     }
     defaultConfigObject.HTTPMaximumConnectionsPerHost = 10;
-    session = [NSURLSession sessionWithConfiguration:defaultConfigObject delegate:self delegateQueue:taskQueue];
+    
+    _session = [NSURLSession sessionWithConfiguration:defaultConfigObject delegate:self delegateQueue:taskQueue];
+    
     if(path != nil || [self.options valueForKey:CONFIG_USE_TEMP]!= nil)
     {
         respFile = YES;
@@ -240,9 +251,27 @@ NSOperationQueue *taskQueue;
         respFile = NO;
     }
 
-    __block NSURLSessionDataTask * task = [session dataTaskWithRequest:req];
-    [taskTable setObject:task forKey:taskId];
-    [task resume];
+    
+    if(uploadTask)
+    {
+        __block NSURLSessionUploadTask * task = [_session uploadTaskWithRequest:req fromFile:[NSURL URLWithString:filepath]];
+        [taskTable setObject:task forKey:taskId];
+        [task resume];
+    }
+    else if(downloadTask)
+    {
+        __block NSURLSessionDownloadTask * task = [_session downloadTaskWithRequest:req];
+        [taskTable setObject:task forKey:taskId];
+        [task resume];
+    }
+    else
+    {
+        __block NSURLSessionDataTask * task = [_session dataTaskWithRequest:req];
+        [taskTable setObject:task forKey:taskId];
+        [task resume];
+    }
+    
+
 
     // network status indicator
     if([[options objectForKey:CONFIG_INDICATOR] boolValue] == YES)
@@ -282,6 +311,7 @@ NSOperationQueue *taskQueue;
 
 
 #pragma mark - Received Response
+
 // set expected content length on response received
 - (void) URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
 {
@@ -383,6 +413,7 @@ NSOperationQueue *taskQueue;
     else
         NSLog(@"oops");
 
+    /*
     if(respFile == YES)
     {
         @try{
@@ -416,12 +447,16 @@ NSOperationQueue *taskQueue;
             NSLog(@"write file error");
         }
     }
+     
+     */
+    
 
     completionHandler(NSURLSessionResponseAllow);
 }
 
 
-// download progress handler
+
+// data download progress handler
 - (void) URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
 {
     // For #143 handling multipart/x-mixed-replace response
@@ -431,6 +466,10 @@ NSOperationQueue *taskQueue;
         return ;
     }
 
+    
+    if(respFile == NO)
+    {
+        
     NSNumber * received = [NSNumber numberWithLong:[data length]];
     receivedBytes += [received longValue];
     NSString * chunkString = @"";
@@ -440,34 +479,168 @@ NSOperationQueue *taskQueue;
         chunkString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     }
 
-    if(respFile == NO)
-    {
         [respData appendData:data];
+        
+        RNFetchBlobProgress * pconfig = [progressTable valueForKey:taskId];
+        if(expectedBytes == 0)
+            return;
+        NSNumber * now =[NSNumber numberWithFloat:((float)receivedBytes/(float)expectedBytes)];
+        RCTLog(@"check the didReceiveData ----%f %f %@",(float)receivedBytes,(float)expectedBytes,taskId);
+        if(pconfig != nil && [pconfig shouldReport:now])
+        {
+            [self.bridge.eventDispatcher
+             sendDeviceEventWithName:EVENT_PROGRESS
+             body:@{
+                    @"taskId": taskId,
+                    @"written": [NSString stringWithFormat:@"%d", receivedBytes],
+                    @"total": [NSString stringWithFormat:@"%d", expectedBytes],
+                    @"chunk": chunkString
+                    }
+             ];
+        }
+        received = nil;
     }
-    else
-    {
-        [writeStream write:[data bytes] maxLength:[data length]];
-    }
-    RNFetchBlobProgress * pconfig = [progressTable valueForKey:taskId];
-    if(expectedBytes == 0)
-        return;
-    NSNumber * now =[NSNumber numberWithFloat:((float)receivedBytes/(float)expectedBytes)];
-    if(pconfig != nil && [pconfig shouldReport:now])
-    {
-        [self.bridge.eventDispatcher
-         sendDeviceEventWithName:EVENT_PROGRESS
-         body:@{
-                @"taskId": taskId,
-                @"written": [NSString stringWithFormat:@"%d", receivedBytes],
-                @"total": [NSString stringWithFormat:@"%d", expectedBytes],
-                @"chunk": chunkString
-            }
-         ];
-    }
-    received = nil;
+   
 
 }
+#pragma mark -
+#pragma mark NSURLSessionDownloadTask delegate methods
+#pragma mark -
 
+  #pragma mark - download progress handler
+
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask
+      didWriteData:(int64_t)bytesWritten
+ totalBytesWritten:(int64_t)totalBytesWritten
+totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
+
+    
+    
+        
+        RNFetchBlobProgress * pconfig = [progressTable valueForKey:taskId];
+        if(totalBytesWritten == 0)
+            return;
+        NSNumber * now =[NSNumber numberWithFloat:((double)bytesWritten/(double)totalBytesWritten)];
+        RCTLog(@"check the now ----%f %f %@",(double)bytesWritten,(double)totalBytesWritten,taskId);
+        if(pconfig != nil && [pconfig shouldReport:now])
+        {
+            [self.bridge.eventDispatcher
+             sendDeviceEventWithName:EVENT_PROGRESS
+             body:@{
+                    @"taskId": taskId,
+                    @"written": [NSString stringWithFormat:@"%d", bytesWritten],
+                    @"total": [NSString stringWithFormat:@"%d", totalBytesWritten]
+                    }
+             ];
+        }
+        
+ 
+}
+
+ #pragma mark - handling didFinishDownloadingToURL
+
+- (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask
+didFinishDownloadingToURL:(NSURL *)location {
+    
+
+   /*
+    @try{
+        NSFileManager * fm = [NSFileManager defaultManager];
+        NSString * folder = [destPath stringByDeletingLastPathComponent];
+        if(![fm fileExistsAtPath:folder])
+        {
+            [fm createDirectoryAtPath:folder withIntermediateDirectories:YES attributes:NULL error:nil];
+        }
+        BOOL overwrite = [options valueForKey:@"overwrite"] == nil ? YES : [[options valueForKey:@"overwrite"] boolValue];
+        BOOL appendToExistingFile = [destPath RNFBContainsString:@"?append=true"];
+        
+        appendToExistingFile = !overwrite;
+        
+        // For solving #141 append response data if the file already exists
+        // base on PR#139 @kejinliang
+        if(appendToExistingFile)
+        {
+            destPath = [destPath stringByReplacingOccurrencesOfString:@"?append=true" withString:@""];
+        }
+        if (![fm fileExistsAtPath:destPath])
+        {
+            [fm createFileAtPath:destPath contents:[[NSData alloc] init] attributes:nil];
+        }
+        writeStream = [[NSOutputStream alloc] initToFileAtPath:destPath append:appendToExistingFile];
+        [writeStream scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+        [writeStream open];
+    }
+    @catch(NSException * ex)
+    {
+        NSLog(@"write file error");
+    }
+    */
+    
+    @try{
+        NSLog(@"file path : %@", destPath);
+        if ([[NSFileManager defaultManager] fileExistsAtPath:destPath]) {
+            //Remove the old file from directory
+            [[NSFileManager defaultManager] removeItemAtPath:destPath error:NULL];
+            
+        }
+        NSError *error;
+        NSURL *documentURL = [NSURL fileURLWithPath:destPath];
+        
+        [[NSFileManager defaultManager] moveItemAtURL:location
+                                                toURL:documentURL
+                                                error:&error];
+        if (!error){
+            
+            //Handle error here
+            
+        }
+    }
+    @catch(NSException * ex)
+    {
+        NSLog(@"write file error");
+    }
+    
+    
+   
+    
+}
+
+#pragma mark - URLSessionDidFinishEventsForBackgroundURLSession
+
+- (void) URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session
+{
+    NSLog(@"sess done in background");
+    
+    AppDelegate *appDelegate = (AppDelegate*)[[UIApplication sharedApplication]delegate];
+    
+    // Check if all download tasks have been finished.
+    [self.session getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks, NSArray *downloadTasks) {
+        if ([downloadTasks count] == 0) {
+            if (appDelegate.backgroundTransferCompletionHandler != nil) {
+                // Copy locally the completion handler.
+                void(^completionHandler)() = appDelegate.backgroundTransferCompletionHandler;
+                
+                // Make nil the backgroundTransferCompletionHandler.
+                appDelegate.backgroundTransferCompletionHandler = nil;
+                
+                [[NSOperationQueue mainQueue] addOperationWithBlock:^{
+                    // Call the completion handler to tell the system that there are no other background transfers.
+                    completionHandler();
+                    
+                    // Show a local notification when all downloads are over.
+                    UILocalNotification *localNotification = [[UILocalNotification alloc] init];
+                    localNotification.alertBody = @"All files have been downloaded!";
+                    [[UIApplication sharedApplication] presentLocalNotificationNow:localNotification];
+                }];
+            }
+        }
+    }];
+    
+    
+}
+
+
+   #pragma mark - Complete and Error callback
 - (void) URLSession:(NSURLSession *)session didBecomeInvalidWithError:(nullable NSError *)error
 {
     if([session isEqual:session])
@@ -497,7 +670,7 @@ NSOperationQueue *taskQueue;
 
     if(respFile == YES)
     {
-        [writeStream close];
+        //[writeStream close];
         rnfbRespType = RESP_TYPE_PATH;
         respStr = destPath;
     }
@@ -580,6 +753,10 @@ NSOperationQueue *taskQueue;
 }
 
 
+
+
+   #pragma mark - Authentication methods
+
 - (void) URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable credantial))completionHandler
 {
     BOOL trusty = [options valueForKey:CONFIG_TRUSTY];
@@ -591,12 +768,6 @@ NSOperationQueue *taskQueue;
     {
         completionHandler(NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust]);
     }
-}
-
-
-- (void) URLSessionDidFinishEventsForBackgroundURLSession:(NSURLSession *)session
-{
-    NSLog(@"sess done in background");
 }
 
 - (void) URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task willPerformHTTPRedirection:(NSHTTPURLResponse *)response newRequest:(NSURLRequest *)request completionHandler:(void (^)(NSURLRequest * _Nullable))completionHandler
@@ -613,5 +784,6 @@ NSOperationQueue *taskQueue;
         completionHandler(nil);
     }
 }
+
 
 @end

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -670,7 +670,7 @@ didFinishDownloadingToURL:(NSURL *)location {
 
     if(respFile == YES)
     {
-        //[writeStream close];
+        [writeStream close];
         rnfbRespType = RESP_TYPE_PATH;
         respStr = destPath;
     }


### PR DESCRIPTION
This adds IOSDownloadTask and IOSUploadTask options so we can transfer files when the app is in the background. Otherwise, the file transfer is halted when not in the foreground and a "Lost connection to background transfer service" error is thrown when the app is resumed.

Borrowed most of the code from #20 , but the progress handler for downloads needed fixing. Also needed to comment out the references to AppDelegate as I wasn't sure how to get that working. 