### PR TITLE
Non-JSON body in string type was converted by JSON.stringify() in fetch. 

### DIFF
--- a/polyfill/Fetch.js
+++ b/polyfill/Fetch.js
@@ -46,7 +46,7 @@ class RNFetchBlobFetchPolyfill {
         // When request body is a Blob, use file URI of the Blob as request body.
         else if (body.isRNFetchBlobPolyfill)
           promise = Promise.resolve(RNFetchBlob.wrap(body.blobPath))
-        else if (typeof body !== 'object' && options.headers['Content-Type'] !== 'application/json')
+        else if (typeof body !== 'string' && options.headers['Content-Type'] !== 'application/json')
           promise = Promise.resolve(JSON.stringify(body))
         else if (typeof body !== 'string')
           promise = Promise.resolve(body.toString())


### PR DESCRIPTION
In polyfill/Fetch.js line 50, the `JSON.stringify()` call is to convert the body into a string, 
however the condition in line 49 is
`typeof body !== 'object' && options.headers['Content-Type'] !== 'application/json'. ` 
If the body is in string type, `JSON.stringify()` will still try to convert the body, which will wrap the body with two extra quotes.  Here is my code:

import RNFetchBlob from 'rn-fetch-blob'

const Fetch = RNFetchBlob.polyfill.Fetch
window.nativeFetch = new Fetch({
    auto : true,
    binaryContentTypes : [
        'application/',
    ]
}).build()

nativeFetch( theURL, {
      timeout: 3000,
      method : 'POST',
      headers: {
        'Accept': 'text/plain',
        'Content-Type': 'application/x-www-form-urlencoded;base64',
      },
      body : '....body in base64....'

I've confirmed that the body arg in Fetch.js is in string type.

Please correct me if I misunderstood something.

Thanks,

Hongyi