### PR TITLE
change android request builder so it wont set Content-Type header to …

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -266,7 +266,9 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                     requestType = RequestType.Form;
                 }
                 else if(cType.isEmpty()) {
-                    builder.header("Content-Type", "application/octet-stream");
+                    if(!cType.equalsIgnoreCase("")) {
+                      builder.header("Content-Type", "application/octet-stream");
+                    }
                     requestType = RequestType.SingleFile;
                 }
                 if(rawRequestBody != null) {


### PR DESCRIPTION
…application/octet-stream if it was explicitly set to the empty string. This fixes amazon s3 uploads with a presigned url

This was fixed in a branch in the original project:
https://github.com/wkh237/react-native-fetch-blob/commit/3b584919d7b1189b055bbd848503a6f6875e0761

And submitted as an issue and tracked in https://github.com/wkh237/react-native-fetch-blob/issues/425

Its required for amazon s3 uploads using a secure upload url, which require the Content-Type header to be set to nothing. It will be called in the JS like so:
```
export function uploadFileToS3(presignedUrl, image) {
  const body = RNFetchBlob.wrap(image.uri.replace('file://', ''));
  return RNFetchBlob.fetch('PUT', presignedUrl,
    {
      'Content-Type': '',
    },
    body
  )
}
```