### PR TITLE
Support RN56: Use sdkVersion / buildToolsVersion from project if set

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ android {
     compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 23
     buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : "23.0.1"
     defaultConfig {
-        minSdkVersion project.hasProperty('minSdkVersion') ? project.targetSdkVersion : 16
+        minSdkVersion project.hasProperty('minSdkVersion') ? project.minSdkVersion : 16
         targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : 23
         versionCode 1
         versionName "1.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,11 +14,11 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? project.compileSdkVersion : 23
+    buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : "23.0.1"
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion project.hasProperty('minSdkVersion') ? project.targetSdkVersion : 16
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : 23
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
Fixes
  > The SDK Build Tools revision (23.0.1) is too low for project ':react-native-fetch-blob'. Minimum required is 25.0.0