### PR TITLE
improvement way to get root SDK versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}'
+    compile "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
     //compile 'com.squareup.okhttp3:okhttp:+'
     //{RNFetchBlob_PRE_0.28_DEPDENDENCY}
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 repositories {
     mavenCentral()
 }
@@ -14,11 +18,11 @@ buildscript {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 26)
+    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"
     }
@@ -33,7 +37,7 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}'
     //compile 'com.squareup.okhttp3:okhttp:+'
     //{RNFetchBlob_PRE_0.28_DEPDENDENCY}
 }


### PR DESCRIPTION
just added a function which acts like a ternary with fallback option. Hence, less cluttered "def" variables  
additionally, changed the SDK values from 23 to 26 as per new changes from react-native and Android

Android Target API Level 26 will be required in August 2018.
https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html

And the React Native team is already working on this:
facebook/react-native#18095
facebook/react-native#17741

PS: I am aware of this PR https://github.com/joltup/rn-fetch-blob/pull/128 but first its still targeting old SDK values i.e 23 as fallback and secondly I am not sure of the use of `project` to get the value instead of proper way i.e `rootProject.ext` to get the property value.