### PR TITLE
Doc update to include note on upgrading across branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 In order to publish new releases from this fork, we have renamed this project to
 `rn-fetch-blob` and published to `https://www.npmjs.com/package/rn-fetch-blob`.
 
+**Note**: If upgrading from the original fork change all references in your project from `react-native-fetch-blob` to `rn-fetch-blob`.  This includes `*.xcodeproj/project.pbxproj` and `android/**/*.gradle` depending on the platform used, failing to do so may cause build errors.
+
 # rn-fetch-blob
 [![release](https://img.shields.io/github/release/joltup/rn-fetch-blob.svg?style=flat-square)](https://github.com/joltup/rn-fetch-blob/releases) [![npm](https://img.shields.io/npm/v/rn-fetch-blob.svg?style=flat-square)](https://www.npmjs.com/package/rn-fetch-blob) ![](https://img.shields.io/badge/PR-Welcome-brightgreen.svg?style=flat-square) [![](https://img.shields.io/badge/Wiki-Public-brightgreen.svg?style=flat-square)](https://github.com/joltup/rn-fetch-blob/wiki) [![npm](https://img.shields.io/npm/l/rn-fetch-blob.svg?maxAge=2592000&style=flat-square)]()
 


### PR DESCRIPTION
As @Traviskn mentioned in #122 I had some lingering references to `react-native-fetch-blob` in my project and thought it might help other folks if there was a note telling them to check.