### PR TITLE
Fix 'Illegal Callback Invocation' Android exception

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -548,6 +548,7 @@ class RNFetchBlobFS {
         path = normalizePath(path);
         InputStream in = null;
         OutputStream out = null;
+        String message = "";
 
         try {
             if(!isPathExists(path)) {
@@ -571,7 +572,7 @@ class RNFetchBlobFS {
                 out.write(buf, 0, len);
             }
         } catch (Exception err) {
-            callback.invoke(err.getLocalizedMessage());
+            message += err.getLocalizedMessage();
         } finally {
             try {
                 if (in != null) {
@@ -580,10 +581,16 @@ class RNFetchBlobFS {
                 if (out != null) {
                     out.close();
                 }
-                callback.invoke();
             } catch (Exception e) {
-                callback.invoke(e.getLocalizedMessage());
+                message += e.getLocalizedMessage();
             }
+        }
+        // Only call the callback once to prevent the app from crashing
+        // with an 'Illegal callback invocation from native module' exception.
+        if (message != "") {
+            callback.invoke(message);
+        } else {
+            callback.invoke();
         }
     }
 


### PR DESCRIPTION
Fixes a case where `callback` was called twice when something went wrong in the `cp` operation, leading to a `java.lang.RuntimeException: Illegal callback invocation from native module. This callback type only permits a single invocation from native code.`

This is the same [as seen in the original repo](https://github.com/wkh237/react-native-fetch-blob/pull/408).

Fixes #35