### PR TITLE
Disable local caching since there is no option to control it

### DIFF
--- a/ios/RNFetchBlobRequest.m
+++ b/ios/RNFetchBlobRequest.m
@@ -117,6 +117,8 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
         defaultConfigObject = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:taskId];
     }
     
+    defaultConfigObject.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+
     // request timeout, -1 if not set in options
     float timeout = [options valueForKey:@"timeout"] == nil ? -1 : [[options valueForKey:@"timeout"] floatValue];
     


### PR DESCRIPTION
The default cache policy is NSURLRequestUseProtocolCachePolicy which caches results and if the same kind of request is made again, adds 'if-none-match' and 'if-modified-since' headers and for example AWS S3 returns an error with if-none-match.

Disable caching altogether since there is no options to control it.

More information here: https://developer.apple.com/documentation/foundation/nsurlrequest/cachepolicy/useprotocolcachepolicy