### PR TITLE
index.d.ts: Fix extends -> implements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -144,7 +144,7 @@ export interface PolyfillProgressEvent extends EventTarget {
     total: number;
 }
 
-export declare class PolyfillBlob extends EventTarget {
+export declare class PolyfillBlob implements EventTarget {
     /**
      * RNFetchBlob Blob polyfill, create a Blob directly from file path, BASE64
      * encoded data, and string. The conversion is done implicitly according to


### PR DESCRIPTION
cc @reilem (Thanks for adding these types in #184!)

Before:
```ts
$ ./node_modules/.bin/tsc
node_modules/rn-fetch-blob/index.d.ts:147:43 - error TS2689: Cannot extend an interface 'EventTarget'. Did you mean 'implements'?

147 export declare class PolyfillBlob extends EventTarget {
                                              ~~~~~~~~~~~

```

After:
```
$ ./node_modules/.bin/tsc
$
```

Versions:
```sh
$ ./node_modules/.bin/tsc --version
Version 3.1.1
```