### PR TITLE
Fix wrap edge cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,13 @@ if(!RNFetchBlob || !RNFetchBlob.fetchBlobForm || !RNFetchBlob.fetchBlob) {
 }
 
 function wrap(path:string):string {
-  const prefix = path.startsWith('content://') ? 'RNFetchBlob-content://' : 'RNFetchBlob-file://'
-  return prefix + path
+  if (path.startsWith('content://')) {
+    return 'RNFetchBlob-content://' + path.substring('content://'.length)
+  } else if (path.startsWith('file://')) {
+    return 'RNFetchBlob-file://' + path.substring('file://'.length)
+  }
+
+  return 'RNFetchBlob-file://' + path
 }
 
 /**


### PR DESCRIPTION
Ensures wrap does not break if the path wrapped starts with `content://` or `file://`.

see: #156, #194 and many issues in the old repo.