### PR TITLE
Update provider_paths.xml to allow access to cache

### DIFF
--- a/android/src/main/res/xml/provider_paths.xml
+++ b/android/src/main/res/xml/provider_paths.xml
@@ -6,4 +6,7 @@
     <files-path
         name="files-path"
         path="." /> <!-- Used to access into application data files -->
+    <cache-path
+        name="cache-path"
+        path="." /> <!-- Used to access files in cache directory -->
 </paths>


### PR DESCRIPTION
Currently, it is not possible to use `android.actionViewIntent` with files that are saved to the `fs.dirs.CacheDir`-directory. By including the cache directory in the provider paths, everything works as expected.