### PR TITLE
actionViewIntent to throw on unsupported file

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -120,11 +120,8 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 // Set flag to give temporary permission to external app to use FileProvider
                 intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
-                // Validate that the device can open the file
-                PackageManager pm = getCurrentActivity().getPackageManager();
-                if (intent.resolveActivity(pm) != null) {
-                    this.getReactApplicationContext().startActivity(intent);
-                }
+                // Do not validate that the device can open the file - instead let it throw
+                this.getReactApplicationContext().startActivity(intent);
 
             } else {
                 Intent intent = new Intent(Intent.ACTION_VIEW)


### PR DESCRIPTION
Currently if a user tries to open an unsupported file, `actionViewIntent` will return a never-resolving promise. I propose to revert back to the functionality of `react-native-fetch-blob`where the promise rejects if the file is unsupported. This can be achieved either by removing the support-check (as I've done here) or at least make the promise reject if the support-check fails.