### PR TITLE
Added support for hashing with secret key. Android only

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -292,6 +292,16 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
         });
     }
 
+    @ReactMethod
+    public void hashWithKey(final String path, final String algorithm, final String key, final Promise promise) {
+        threadPool.execute(new Runnable() {
+            @Override
+            public void run() {
+                RNFetchBlobFS.hashWithKey(path, algorithm, key, promise);
+            }
+        });
+    }
+
     /**
      * @param path Stream file path
      * @param encoding Stream encoding, should be one of `base64`, `ascii`, and `utf8`

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -9,7 +9,7 @@ import android.os.Environment;
 import android.os.StatFs;
 import android.os.SystemClock;
 import android.util.Base64;
-
+import android.util.Log;
 import com.RNFetchBlob.Utils.PathResolver;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 
 class RNFetchBlobFS {
 
@@ -893,6 +895,44 @@ class RNFetchBlobFS {
             promise.reject("EUNSPECIFIED", e.getLocalizedMessage());
         }
     }
+
+    static void hashWithKey(String path, String algorithm, String key, Promise promise) {
+        try {           
+            File file = new File(path);
+
+            if (file.isDirectory()) {
+                promise.reject("EISDIR", "Expecting a file but '" + path + "' is a directory");
+                return;
+            }
+
+            if (!file.exists()) {
+                promise.reject("ENOENT", "No such file '" + path + "'");
+                return;
+            }            
+
+            SecretKeySpec secretKeySpec = new SecretKeySpec(key.getBytes(), algorithm);            
+            Mac mac = Mac.getInstance(algorithm);
+            mac.init(secretKeySpec);
+            
+            FileInputStream inputStream = new FileInputStream(path);            
+            byte[] buffer = new byte[(int)file.length()];
+            
+            int read;
+            while ((read = inputStream.read(buffer)) != -1) {                                
+                mac.update(buffer, 0, read);
+            }
+           
+            StringBuilder hexString = new StringBuilder();
+            for (byte digestByte : mac.doFinal()){                
+                hexString.append(String.format("%02x", digestByte));
+            }            
+
+            promise.resolve(hexString.toString());
+        } catch (Exception e) {
+            e.printStackTrace();
+            promise.reject("EUNSPECIFIED", e.getLocalizedMessage());
+        }
+    }    
 
     /**
      * Create new file at path

--- a/fs.js
+++ b/fs.js
@@ -245,6 +245,13 @@ function hash(path: string, algorithm: string): Promise<string> {
   return RNFetchBlob.hash(path, algorithm)
 }
 
+function hashWithKey(path: string, algorithm: string, key: string): Promise<string> {
+  if (typeof path !== 'string' || typeof algorithm !== 'string' || typeof key !== 'string') {
+    return Promise.reject(addCode('EINVAL', new TypeError('Missing argument "path" and/or "algorithm" and/or "key"')))
+  }
+  return RNFetchBlob.hashWithKey(path, algorithm, key)
+}
+
 function cp(path: string, dest: string): Promise<boolean> {
   return new Promise((resolve, reject) => {
     if (typeof path !== 'string' || typeof dest !== 'string') {
@@ -404,6 +411,7 @@ export default {
   pathForAppGroup,
   readFile,
   hash,
+  hashWithKey,
   exists,
   createFile,
   isDir,


### PR DESCRIPTION
Usage:
```
let myAlgorithm = "HmacMD5"; // can be HmacSHA1, HmacSHA256, etc...
let mySecretKey = "secret"; // secret key

RNFetchBlob.fs.hashWithKey(targetPath, myAlgorithm, mySecretKey)
.then((hash) => {
  console.log(hash)
})
.catch((error) => {
  console.log(error);
});
```

if this is accepted hopefully someone apply it for ios too