### PR TITLE
Update build.grade to use implementation instead of compile

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
     //compile 'com.squareup.okhttp3:okhttp:+'
     //{RNFetchBlob_PRE_0.28_DEPDENDENCY}
 }


### PR DESCRIPTION
`compile` has been replaced by `implementation`, see http://d.android.com/r/tools/update-dependency-configurations.html

By the way, `compile` will be removed by the end of 2018.