### PR TITLE
Use android-tools repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ repositories {
 
 buildscript {
     repositories {
-        jcenter()
+        maven { url "https://dl.bintray.com/android/android-tools/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.3'


### PR DESCRIPTION
Build tools version `2.2.3` is no longer available at JCenter: [Available Versions](https://jcenter.bintray.com/com/android/tools/build/gradle/).
This causes build fails, in order to fix it I propose switching to the [`android-tools` Repository](https://dl.bintray.com/android/android-tools/).