### PR TITLE
fixed wrong path returned in case file downloaded with name suffix like -1, -2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
-# New Releases
-In order to publish new releases from this fork, we have renamed this project to
-`rn-fetch-blob` and published to `https://www.npmjs.com/package/rn-fetch-blob`.
-
-**Note**: If upgrading from the original fork change all references in your project from `react-native-fetch-blob` to `rn-fetch-blob`.  This includes `*.xcodeproj/project.pbxproj` and `android/**/*.gradle` depending on the platform used, failing to do so may cause build errors.
-
 # rn-fetch-blob
 [![release](https://img.shields.io/github/release/joltup/rn-fetch-blob.svg?style=flat-square)](https://github.com/joltup/rn-fetch-blob/releases) [![npm](https://img.shields.io/npm/v/rn-fetch-blob.svg?style=flat-square)](https://www.npmjs.com/package/rn-fetch-blob) ![](https://img.shields.io/badge/PR-Welcome-brightgreen.svg?style=flat-square) [![](https://img.shields.io/badge/Wiki-Public-brightgreen.svg?style=flat-square)](https://github.com/joltup/rn-fetch-blob/wiki) [![npm](https://img.shields.io/npm/l/rn-fetch-blob.svg?maxAge=2592000&style=flat-square)]()
 
-
 A project committed to making file access and data transfer easier and more efficient for React Native developers.
-> For Firebase Storage solution, please upgrade to the latest version for the best compatibility.
+
+# Version Compatibility Warning
+
+rn-fetch-blob version 0.10.16 is only compatible with react native 0.60 and up. It should have been a major version bump, we apologize for the mistake. If you are not yet upgraded to react native 0.60 or above, you should remain on rn-fetch-blob version 0.10.15
 
 ## Features
 - Transfer data directly from/to storage without BASE64 bridging

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,8 @@ def safeExtGet(prop, fallback) {
 
 repositories {
     mavenCentral()
+    jcenter()
+    google()
 }
 
 buildscript {
@@ -14,16 +16,16 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 26)
-    buildToolsVersion safeExtGet('buildToolsVersion', '26.0.3')
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 26)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,2 @@
+android.enableJetifier=true
+android.useAndroidX=true

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
     <application android:label="@string/app_name">
 
         <provider
-            android:name="android.support.v4.content.FileProvider"
+            android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
     <application android:label="@string/app_name">
 
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name="com.RNFetchBlob.Utils.FileProvider"
             android:authorities="${applicationId}.provider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -6,7 +6,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Build;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 import android.util.SparseArray;
 
 import com.facebook.react.bridge.ActivityEventListener;
@@ -28,7 +28,6 @@ import okhttp3.OkHttpClient;
 import okhttp3.JavaNetCookieJar;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobBody.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobBody.java
@@ -1,6 +1,6 @@
 package com.RNFetchBlob;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Base64;
 
 import com.facebook.react.bridge.Arguments;

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -8,7 +8,7 @@ import android.content.IntentFilter;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Build;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Base64;
 
 import com.RNFetchBlob.Response.RNFetchBlobDefaultResp;
@@ -16,7 +16,6 @@ import com.RNFetchBlob.Response.RNFetchBlobFileResp;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
-import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -674,10 +674,10 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                     return;
                 }
 
+                String filePath = null;
+                String contentUri = null;
+
                 try { 
-                    String filePath = null;
-                    String contentUri = null;
-                    
                     // the file exists in media content database
                     if (c.moveToFirst()) {
 

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -23,6 +23,7 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
+import java.net.URLDecoder;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
@@ -669,6 +670,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
 
 
                 String filePath = null;
+                String contentUri = null;
                 // the file exists in media content database
                 if (c.moveToFirst()) {
                     // #297 handle failed request
@@ -677,7 +679,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                         this.callback.invoke("Download manager failed to download from  " + this.url + ". Status Code = " + statusCode, null, null);
                         return;
                     }
-                    String contentUri = c.getString(c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI));
+                    contentUri = c.getString(c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI));
                     if ( contentUri != null &&
                             options.addAndroidDownloads.hasKey("mime") &&
                             options.addAndroidDownloads.getString("mime").contains("image")) {
@@ -696,6 +698,21 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 if (options.addAndroidDownloads.hasKey("path")) {
                     try {
                         String customDest = options.addAndroidDownloads.getString("path");
+                        // checking if file is uploaded with different name
+                        if (contentUri != null && contentUri.length() != 0) {
+                            int lastIndexOfInPath = customDest.lastIndexOf("/");
+                            if (lastIndexOfInPath != -1) {
+                                int lastIndexOfInContentUri = contentUri.lastIndexOf("/");
+                                if (lastIndexOfInContentUri != -1) {
+                                    String newPath = customDest.substring(0, lastIndexOfInPath) + contentUri.substring(lastIndexOfInContentUri);
+                                    try {
+                                        // updating path with new file name
+                                        customDest = URLDecoder.decode(newPath, "UTF-8");
+                                    } catch (Exception exception) {}
+                                }
+                            }
+                        }
+                        
                         boolean exists = new File(customDest).exists();
                         if(!exists)
                             throw new Exception("Download manager download failed, the file does not downloaded to destination.");

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -668,29 +668,42 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 dm.query(query);
                 Cursor c = dm.query(query);
 
+                // #236 unhandled null check for DownloadManager.query() return value
+                if (c == null) {
+                    this.callback.invoke("Download manager failed to download from  " + this.url + ". Query was unsuccessful ", null, null);
+                    return;
+                }
 
-                String filePath = null;
-                String contentUri = null;
-                // the file exists in media content database
-                if (c.moveToFirst()) {
-                    // #297 handle failed request
-                    int statusCode = c.getInt(c.getColumnIndex(DownloadManager.COLUMN_STATUS));
-                    if(statusCode == DownloadManager.STATUS_FAILED) {
-                        this.callback.invoke("Download manager failed to download from  " + this.url + ". Status Code = " + statusCode, null, null);
-                        return;
-                    }
-                    contentUri = c.getString(c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI));
-                    if ( contentUri != null &&
-                            options.addAndroidDownloads.hasKey("mime") &&
-                            options.addAndroidDownloads.getString("mime").contains("image")) {
-                        Uri uri = Uri.parse(contentUri);
-                        Cursor cursor = appCtx.getContentResolver().query(uri, new String[]{android.provider.MediaStore.Images.ImageColumns.DATA}, null, null, null);
-                        // use default destination of DownloadManager
-                        if (cursor != null) {
-                            cursor.moveToFirst();
-                            filePath = cursor.getString(0);
-                            cursor.close();
+                try { 
+                    String filePath = null;
+                    String contentUri = null;
+                    
+                    // the file exists in media content database
+                    if (c.moveToFirst()) {
+
+                        // #297 handle failed request
+                        int statusCode = c.getInt(c.getColumnIndex(DownloadManager.COLUMN_STATUS));
+                        if(statusCode == DownloadManager.STATUS_FAILED) {
+                            this.callback.invoke("Download manager failed to download from  " + this.url + ". Status Code = " + statusCode, null, null);
+                            return;
                         }
+                        contentUri = c.getString(c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI));
+                        if ( contentUri != null &&
+                                options.addAndroidDownloads.hasKey("mime") &&
+                                options.addAndroidDownloads.getString("mime").contains("image")) {
+                            Uri uri = Uri.parse(contentUri);
+                            Cursor cursor = appCtx.getContentResolver().query(uri, new String[]{android.provider.MediaStore.Images.ImageColumns.DATA}, null, null, null);
+                            // use default destination of DownloadManager
+                            if (cursor != null) {
+                                cursor.moveToFirst();
+                                filePath = cursor.getString(0);
+                                cursor.close();
+                            }
+                        }
+                    }
+                } finally {
+                    if (c != null) {
+                        c.close();
                     }
                 }
 

--- a/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java
+++ b/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java
@@ -1,7 +1,6 @@
 package com.RNFetchBlob.Response;
 
-import android.support.annotation.NonNull;
-import android.util.Log;
+import androidx.annotation.NonNull;
 
 import com.RNFetchBlob.RNFetchBlobConst;
 import com.RNFetchBlob.RNFetchBlobProgressConfig;

--- a/android/src/main/java/com/RNFetchBlob/Utils/FileProvider.java
+++ b/android/src/main/java/com/RNFetchBlob/Utils/FileProvider.java
@@ -1,0 +1,4 @@
+package com.RNFetchBlob.Utils;
+
+public class FileProvider extends androidx.core.content.FileProvider {
+}

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ import {
   DeviceEventEmitter,
   NativeAppEventEmitter,
   Platform,
-  AsyncStorage,
   AppState,
 } from 'react-native'
 import type {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-fetch-blob",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mesameerahmed/rn-fetch-blob",
-  "version": "0.10.16.1",
+  "version": "0.10.16.2",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rn-fetch-blob",
+  "name": "@mesameerahmed/rn-fetch-blob",
   "version": "0.10.16",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
@@ -27,7 +27,7 @@
     }
   },
   "repository": {
-    "url": "https://github.com/joltup/rn-fetch-blob.git"
+    "url": "https://github.com/sameer-ahmed/rn-fetch-blob.git"
   },
   "author": "Joltup",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mesameerahmed/rn-fetch-blob",
-  "version": "0.10.16.2",
+  "version": "0.10.16.3",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mesameerahmed/rn-fetch-blob",
-  "version": "0.10.16",
+  "version": "0.10.16.1",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {

--- a/polyfill/FileReader.js
+++ b/polyfill/FileReader.js
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import RNFetchBlob from '../index.js'
 import ProgressEvent from './ProgressEvent.js'
 import EventTarget from './EventTarget'
 import Blob from './Blob'

--- a/rn-fetch-blob.podspec
+++ b/rn-fetch-blob.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.author       = 'Joltup'
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "8.0"
-  s.dependency 'React/Core'
+  s.dependency 'React-Core'
 end

--- a/rn-fetch-blob.podspec
+++ b/rn-fetch-blob.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name             = "rn-fetch-blob"
-  s.version          = "0.10.6"
+  s.version          = "0.10.16"
   s.summary          = "A project committed to make file acess and data transfer easier, effiecient for React Native developers."
   s.requires_arc = true
   s.license      = 'MIT'
   s.homepage     = 'n/a'
-  s.source       = { :git => "https://github.com/joltup/rn-fetch-blob", :tag => 'v0.10.10'}
+  s.source       = { :git => "https://github.com/joltup/rn-fetch-blob", :tag => 'v0.10.16'}
   s.author       = 'Joltup'
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "8.0"


### PR DESCRIPTION
if a file already exists at path and user try to download it again, it will be downloaded with a new name which is following

`original file name` + `-1`

but returned local path in res.path() is the path with old filename if the user has given the custom `path` in fetch config.

expected: res.path() should be returned the original download `path` not the path wich user gave as `path` config