### PR TITLE
Add RNFetchblob.fs.hash function to type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -293,6 +293,7 @@ export interface Net {
     removeCookies(domain?: string): Promise<null>;
 }
 
+type HashAlgorithm = "md5" | "sha1" | "sha224" | "sha256" | "sha384" | "sha512";
 export interface FS {
     RNFetchBlobSession: RNFetchBlobSession;
 
@@ -315,6 +316,14 @@ export interface FS {
     session(name: string): RNFetchBlobSession;
 
     ls(path: string): Promise<string[]>;
+
+    /**
+     * Read the file from the given path and calculate a cryptographic hash sum over its contents.
+     *
+     * @param path Path to the file
+     * @param algorithm The hash algorithm to use
+     */
+    hash(path: string, algorithm: HashAlgorithm);
 
     /**
      * Create file stream from file at `path`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -323,7 +323,7 @@ export interface FS {
      * @param path Path to the file
      * @param algorithm The hash algorithm to use
      */
-    hash(path: string, algorithm: HashAlgorithm);
+    hash(path: string, algorithm: HashAlgorithm): Promise<string>;
 
     /**
      * Create file stream from file at `path`.


### PR DESCRIPTION
The RNFetchblob.fs.hash function is missing in the typedef file for typescript, and is added in this PR. 

I am aware of the rn-fetch-blob-dev repository but this seems to be a trivial change. Please tell me if I should submit the PR there instead.

PS: This is my first time actually submitting a PR to an open source project, so sorry in advance if there's anything I am doing wrong.

