### PR TITLE
[BUG] Fix missing promise

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -123,7 +123,14 @@ function mkdir(path: string): Promise {
   if (typeof path !== 'string') {
     return Promise.reject(addCode('EINVAL', new TypeError('Missing argument "path" ')))
   }
-  return RNFetchBlob.mkdir(path)
+  return new Promise((resolve, reject) => {
+    RNFetchBlob.mkdir(path, (err, res) => {
+      if(err)
+        reject(new Error(err))
+      else
+        resolve()
+    })
+  })
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-fetch-blob",
-  "version": "0.10.15",
+  "version": "0.10.16",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
RNFetchBlob.mkdir requires two arguments, the second being a promise. This re-implements that and stops it crashing..