### PR TITLE
require cycle

### DIFF
--- a/polyfill/Fetch.js
+++ b/polyfill/Fetch.js
@@ -1,4 +1,3 @@
-import RNFetchBlob from '../index.js'
 import Log from '../utils/log.js'
 import fs from '../fs'
 import unicode from '../utils/unicode'


### PR DESCRIPTION
This fixed the warning for "require cycle" on newer React-Versions