### PR TITLE
require cycle

### DIFF
--- a/polyfill/FileReader.js
+++ b/polyfill/FileReader.js
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import RNFetchBlob from '../index.js'
 import ProgressEvent from './ProgressEvent.js'
 import EventTarget from './EventTarget'
 import Blob from './Blob'


### PR DESCRIPTION
This fixed the warning for "require cycle" on newer React-Versions