### PR TITLE
require cycle

### DIFF
--- a/polyfill/XMLHttpRequest.js
+++ b/polyfill/XMLHttpRequest.js
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import RNFetchBlob from '../index.js'
 import XMLHttpRequestEventTarget from './XMLHttpRequestEventTarget.js'
 import Log from '../utils/log.js'
 import Blob from './Blob.js'


### PR DESCRIPTION
This fixed the warning for "require cycle" on newer React-Versions