### PR TITLE
feat: support paths from RCTImageStoreManager

### DIFF
--- a/ios/RNFetchBlob/RNFetchBlob.h
+++ b/ios/RNFetchBlob/RNFetchBlob.h
@@ -18,12 +18,14 @@
 #import <React/RCTBridge.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTBridgeModule.h>
+#import <React/RCTImageStoreManager.h>
 #else
 #import "RCTBridgeModule.h"
 #import "RCTLog.h"
 #import "RCTRootView.h"
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
+#import "RCTImageStoreManager.h"
 #endif
 
 #import <UIKit/UIKit.h>

--- a/ios/RNFetchBlobConst.h
+++ b/ios/RNFetchBlobConst.h
@@ -24,6 +24,7 @@ extern NSString *const EVENT_PROGRESS_UPLOAD;
 extern NSString *const EVENT_STATE_CHANGE;
 
 extern NSString *const FILE_PREFIX;
+extern NSString *const IMAGE_STORE_PREFIX;
 extern NSString *const ASSET_PREFIX;
 extern NSString *const AL_PREFIX;
 

--- a/ios/RNFetchBlobConst.m
+++ b/ios/RNFetchBlobConst.m
@@ -8,6 +8,7 @@
 #import "RNFetchBlobConst.h"
 
 NSString *const FILE_PREFIX = @"RNFetchBlob-file://";
+NSString *const IMAGE_STORE_PREFIX = @"rct-image-store://";
 NSString *const ASSET_PREFIX = @"bundle-assets://";
 NSString *const AL_PREFIX = @"assets-library://";
 


### PR DESCRIPTION
The Image Store is a built-in native-side image cache (for iOS, see [this](https://github.com/tradle/react-native-image-store) module for Android support). This is useful to avoid sending images over the bridge in various modules (camera, document scanners, etc). 