### PR TITLE
Updated for iOS

### DIFF
--- a/ios/RNFetchBlobReqBuilder.m
+++ b/ios/RNFetchBlobReqBuilder.m
@@ -69,7 +69,7 @@
                 [mheaders setValue:[NSString stringWithFormat:@"%lu",[postData length]] forKey:@"Content-Length"];
                 [mheaders setValue:@"100-continue" forKey:@"Expect"];
                 // appaned boundary to content-type
-                [mheaders setValue:[NSString stringWithFormat:@"multipart/form-data; charset=utf-8; boundary=%@", boundary] forKey:@"content-type"];
+                [mheaders setValue:[NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary] forKey:@"content-type"];
                 [request setHTTPMethod: method];
                 [request setAllHTTPHeaderFields:mheaders];
                 onComplete(request, [formData length]);


### PR DESCRIPTION
For some server types, specifically Apache Tomcat, the addition of 'charset=utf-8' to the content-type headers is not required on iOS in case of multipart/form-data and causes the server to ignore files in case that's what the multipart content contains.

On Android, the content-type header doesn't carry this additional parameter.

Removing it from iOS now. In case this is required for a specific type of multipart content then we should discuss it and write additional conditions for the same.
