### PR TITLE
Remove unsafe http client util and references

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -221,12 +221,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
         OkHttpClient.Builder clientBuilder;
 
         try {
-            // use trusty SSL socket
-            if (this.options.trusty) {
-                clientBuilder = RNFetchBlobUtils.getUnsafeOkHttpClient(client);
-            } else {
-                clientBuilder = client.newBuilder();
-            }
+            clientBuilder = client.newBuilder();
 
             final Request.Builder builder = new Request.Builder();
             try {

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobUtils.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobUtils.java
@@ -52,45 +52,4 @@ public class RNFetchBlobUtils {
         RNFetchBlob.RCTContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                 .emit(RNFetchBlobConst.EVENT_MESSAGE, args);
     }
-
-    public static OkHttpClient.Builder getUnsafeOkHttpClient(OkHttpClient client) {
-        try {
-            // Create a trust manager that does not validate certificate chains
-            final TrustManager[] trustAllCerts = new TrustManager[]{
-                    new X509TrustManager() {
-                        @Override
-                        public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
-                        }
-
-                        @Override
-                        public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
-                        }
-
-                        @Override
-                        public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-                            return new java.security.cert.X509Certificate[]{};
-                        }
-                    }
-            };
-
-            // Install the all-trusting trust manager
-            final SSLContext sslContext = SSLContext.getInstance("SSL");
-            sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
-            // Create an ssl socket factory with our all-trusting manager
-            final SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
-
-            OkHttpClient.Builder builder = client.newBuilder();
-            builder.sslSocketFactory(sslSocketFactory);
-            builder.hostnameVerifier(new HostnameVerifier() {
-                @Override
-                public boolean verify(String hostname, SSLSession session) {
-                    return true;
-                }
-            });
-
-            return builder;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
 }


### PR DESCRIPTION
When doing security scans of an app that includes this library this code gets flagged as unsafe and advised not to be released. 

Can this just be removed?