### PR TITLE
Add the FLAG_ACTIVITY_NEW_TASK flag.

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -120,6 +120,8 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 // Set flag to give temporary permission to external app to use FileProvider
                 intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
+                // All the activity to be opened outside of an activity
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 // Validate that the device can open the file
                 PackageManager pm = getCurrentActivity().getPackageManager();
                 if (intent.resolveActivity(pm) != null) {


### PR DESCRIPTION
This is caused by an error on Android 9: 'Error: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?'