### PR TITLE
Remove unused AsyncStorage import (Deprecated in RN 0.59)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ import {
   DeviceEventEmitter,
   NativeAppEventEmitter,
   Platform,
-  AsyncStorage,
   AppState,
 } from 'react-native'
 import type {


### PR DESCRIPTION
AsyncStorage has been deprecated but doesn't look like it's being used anyway, so this PR removes it.