### PR TITLE
info() method definition for FetchBlobResponse

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -96,6 +96,7 @@ export interface FetchBlobResponse {
      */
     flush(): void;
     respInfo: RNFetchBlobResponseInfo;
+    info(): RNFetchBlobResponseInfo;
     session(name: string): RNFetchBlobSession | null;
     /**
      * Read file content with given encoding, if the response does not contains


### PR DESCRIPTION
Added TypeScript definition for method info() of interface FetchBlobResponse