### PR TITLE
Cancel download throw error bugfix (Android)

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,8 +229,14 @@ function fetch(...args:any):Promise {
     return fetchFile(options, method, url, headers, body)
   }
 
+  let promiseResolve;
+  let promiseReject;
+
   // from remote HTTP(S)
   let promise = new Promise((resolve, reject) => {
+    promiseResolve = resolve;
+    promiseReject = reject;
+
     let nativeMethodName = Array.isArray(body) ? 'fetchBlobForm' : 'fetchBlob'
 
     // on progress event listener
@@ -371,6 +377,7 @@ function fetch(...args:any):Promise {
     subscriptionUpload.remove()
     stateEvent.remove()
     RNFetchBlob.cancelRequest(taskId, fn)
+    promiseReject(new Error("canceled"))
   }
   promise.taskId = taskId
 


### PR DESCRIPTION
This PR is based on #363 
In which @minextu wrote:
```
Moved from wkh237#568
Fixes #182

Original Description:

Issue wkh237#555 describes that aborting a download does not lead to promise rejection. This bug has been fixed so that both at Android and iOS the promise will be rejected.
```
Basically he found a working PR that was put up against the old `wkh237` repo but was obviously out of date.

PR #363 has a couple of unnecessary commits attached to it so I've simply took the only commit that actually fixes the problem and made a new PR with that. 

Tested this against iOS and Android and now both platform are throwing a catchable Error whenever you call `.cancel()` on fetch request as the [documentation says it should](https://github.com/joltup/rn-fetch-blob/wiki/Fetch-API#fetchcanceleventlistenerpromisernfetchblobresponse)

@Traviskn Can you review/merge this in when you get a chance, pretty harmless PR that fixes an old problem.

For anyone needing this functionality point to this repo/branch:
```
"rn-fetch-blob": "git+https://github.com/repodio/rn-fetch-blob.git#throw-on-cancel-android"
```
until this PR has been merged