### PR TITLE
Bug fix for download interruption promise rejection

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -531,16 +531,26 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 }
                 break;
             case FileStorage:
+                ResponseBody responseBody = resp.body();
+
                 try {
                     // In order to write response data to `destPath` we have to invoke this method.
                     // It uses customized response body which is able to report download progress
                     // and write response data to destination path.
-                    resp.body().bytes();
+                    responseBody.bytes();
                 } catch (Exception ignored) {
 //                    ignored.printStackTrace();
                 }
-                this.destPath = this.destPath.replace("?append=true", "");
-                callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_PATH, this.destPath);
+
+                RNFetchBlobFileResp rnFetchBlobFileResp = (RNFetchBlobFileResp) responseBody;
+
+                if(rnFetchBlobFileResp != null && rnFetchBlobFileResp.isDownloadComplete() == false){
+                    callback.invoke("RNFetchBlob failed. Download interrupted.", null);
+                }
+                else {
+                    this.destPath = this.destPath.replace("?append=true", "");
+                    callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_PATH, this.destPath);
+                }
                 break;
             default:
                 try {

--- a/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java
+++ b/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java
@@ -69,6 +69,10 @@ public class RNFetchBlobFileResp extends ResponseBody {
         return originalBody.contentLength();
     }
 
+    public boolean isDownloadComplete() {
+        return bytesDownloaded == contentLength();
+    }
+
     @Override
     public BufferedSource source() {
         ProgressReportingSource countable = new ProgressReportingSource();


### PR DESCRIPTION
Resolving the issue https://github.com/wkh237/react-native-fetch-blob/issues/264. Current version doesn't throw a promise rejection upon incomplete file download to storage directly, on android. I am providing a fix by comparing the bytes downloaded with the content length.

Tested on android. Throws _RNFetchBlob failed. Download interrupted_ upon interruption.