### PR TITLE
fix cocoa pod 0.60.0 for rn-fetch-blob

### DIFF
--- a/rn-fetch-blob.podspec
+++ b/rn-fetch-blob.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.author       = 'Joltup'
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "8.0"
-  s.dependency 'React/Core'
+  s.dependency 'React'
 end

--- a/rn-fetch-blob.podspec
+++ b/rn-fetch-blob.podspec
@@ -9,5 +9,5 @@ Pod::Spec.new do |s|
   s.author       = 'Joltup'
   s.source_files = 'ios/**/*.{h,m}'
   s.platform     = :ios, "8.0"
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
- Hi, cause of React/Core is not found with react-native version 0.60.0 in cocoa pod. React Native also has moved React to cocoa pod. This is for fixing React/Core is not found in updating.

Please check again & merge it :)

Thanks,
Cong