### PR TITLE
Fix cyclic dependencies between polyfill files and root/index.js

### DIFF
--- a/polyfill/Blob.js
+++ b/polyfill/Blob.js
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import RNFetchBlob from '../index.js'
+import { NativeModules } from 'react-native'
 import fs from '../fs.js'
 import getUUID from '../utils/uuid'
 import Log from '../utils/log.js'
 import EventTarget from './EventTarget'
 
+const RNFetchBlob = NativeModules.RNFetchBlob
 const log = new Log('Blob')
 const blobCacheDir = fs.dirs.DocumentDir + '/RNFetchBlob-blobs/'
 
@@ -291,7 +292,7 @@ export default class Blob extends EventTarget {
     if(!this._isReference) {
       return fs.unlink(this._ref).catch((err) => {
         console.warn(err)
-      })   
+      })
     }
     else {
       return Promise.resolve()

--- a/polyfill/Fetch.js
+++ b/polyfill/Fetch.js
@@ -1,9 +1,10 @@
-import RNFetchBlob from '../index.js'
+import { NativeModules } from 'react-native'
 import Log from '../utils/log.js'
 import fs from '../fs'
 import unicode from '../utils/unicode'
 import Blob from './Blob'
 
+const RNFetchBlob = NativeModules.RNFetchBlob
 const log = new Log('FetchPolyfill')
 
 log.disable()

--- a/polyfill/FileReader.js
+++ b/polyfill/FileReader.js
@@ -2,13 +2,14 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import RNFetchBlob from '../index.js'
+import { NativeModules } from 'react-native'
 import ProgressEvent from './ProgressEvent.js'
 import EventTarget from './EventTarget'
 import Blob from './Blob'
 import Log from '../utils/log.js'
 import fs from '../fs'
 
+const RNFetchBlob = NativeModules.RNFetchBlob
 const log = new Log('FileReader')
 
 log.level(3)

--- a/polyfill/XMLHttpRequest.js
+++ b/polyfill/XMLHttpRequest.js
@@ -2,13 +2,14 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import RNFetchBlob from '../index.js'
+import { NativeModules } from 'react-native'
 import XMLHttpRequestEventTarget from './XMLHttpRequestEventTarget.js'
 import Log from '../utils/log.js'
 import Blob from './Blob.js'
 import ProgressEvent from './ProgressEvent.js'
 import URIUtil from '../utils/uri'
 
+const RNFetchBlob = NativeModules.RNFetchBlob
 const log = new Log('XMLHttpRequest')
 
 log.disable()


### PR DESCRIPTION
As the title states, this resolves cyclic dependency warnings and possible issues between the files found in the `polyfill` directory and the root `index.js` file. 

These warnings:
![Screen Shot 2019-07-19 at 13 58 22](https://user-images.githubusercontent.com/28015757/61533524-6ec27a00-aa2d-11e9-81b8-cedbeee1da43.png)
