### PR TITLE
Create sync method to App Group dir

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -136,6 +136,19 @@ function pathForAppGroup(groupName: string): Promise {
 }
 
 /**
+ * Returns the path for the app group synchronous.
+ * @param  {string} groupName Name of app group
+ * @return {string} Path of App Group dir
+ */
+function syncPathAppGroup(groupName: string): string {
+  if (Platform.OS === 'ios') {
+    return RNFetchBlob.syncPathAppGroup(groupName);
+  } else {
+    return '';
+  }
+}
+
+/**
  * Wrapper method of readStream.
  * @param  {string} path Path of the file.
  * @param  {'base64' | 'utf8' | 'ascii'} encoding Encoding of read stream.
@@ -402,6 +415,7 @@ export default {
   writeFile,
   appendFile,
   pathForAppGroup,
+  syncPathAppGroup,
   readFile,
   hash,
   exists,

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -228,6 +228,18 @@ RCT_EXPORT_METHOD(pathForAppGroup:(NSString *)groupName
     }
 }
 
+#pragma mark - fs.syncPathAppGroup
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(syncPathAppGroup:(NSString *)groupName) {
+    NSURL *pathUrl = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:groupName];
+    NSString *path = [pathUrl path];
+
+    if(path) {
+        return path;
+    } else {
+        return @"";
+    }
+}
+
 #pragma mark - fs.exists
 RCT_EXPORT_METHOD(exists:(NSString *)path callback:(RCTResponseSenderBlock)callback) {
     [RNFetchBlobFS exists:path callback:callback];


### PR DESCRIPTION
Probably is more clean and better if we give a App Group path in a synchronous constant.