### PR TITLE
Bug fix for download interruption promise rejection

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -530,16 +530,26 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 }
                 break;
             case FileStorage:
+                ResponseBody responseBody = resp.body();
+
                 try {
                     // In order to write response data to `destPath` we have to invoke this method.
                     // It uses customized response body which is able to report download progress
                     // and write response data to destination path.
-                    resp.body().bytes();
+                    responseBody.bytes();
                 } catch (Exception ignored) {
 //                    ignored.printStackTrace();
                 }
-                this.destPath = this.destPath.replace("?append=true", "");
-                callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_PATH, this.destPath);
+
+                RNFetchBlobFileResp rnFetchBlobFileResp = (RNFetchBlobFileResp) responseBody;
+
+                if(rnFetchBlobFileResp != null && rnFetchBlobFileResp.isDownloadComplete() == false){
+                    callback.invoke("RNFetchBlob failed. Download interrupted.", null);
+                }
+                else {
+                    this.destPath = this.destPath.replace("?append=true", "");
+                    callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_PATH, this.destPath);
+                }
                 break;
             default:
                 try {

--- a/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java
+++ b/android/src/main/java/com/RNFetchBlob/Response/RNFetchBlobFileResp.java
@@ -33,6 +33,7 @@ public class RNFetchBlobFileResp extends ResponseBody {
     long bytesDownloaded = 0;
     ReactApplicationContext rctContext;
     FileOutputStream ofStream;
+    boolean isEndMarkerReceived;
 
     public RNFetchBlobFileResp(ReactApplicationContext ctx, String taskId, ResponseBody body, String path, boolean overwrite) throws IOException {
         super();
@@ -41,6 +42,7 @@ public class RNFetchBlobFileResp extends ResponseBody {
         this.originalBody = body;
         assert path != null;
         this.mPath = path;
+        this.isEndMarkerReceived = false;
         if (path != null) {
             boolean appendToExistingFile = !overwrite;
             path = path.replace("?append=true", "");
@@ -68,6 +70,11 @@ public class RNFetchBlobFileResp extends ResponseBody {
         return originalBody.contentLength();
     }
 
+    public boolean isDownloadComplete() {
+        return (bytesDownloaded == contentLength()) // Case of non-chunked downloads
+                || (contentLength() == -1 && isEndMarkerReceived); // Case of chunked downloads
+    }
+
     @Override
     public BufferedSource source() {
         ProgressReportingSource countable = new ProgressReportingSource();
@@ -83,20 +90,47 @@ public class RNFetchBlobFileResp extends ResponseBody {
                 bytesDownloaded += read > 0 ? read : 0;
                 if (read > 0) {
                     ofStream.write(bytes, 0, (int) read);
+                } else if (contentLength() == -1 && read == -1) {
+                    // End marker has been received for chunked download
+                    isEndMarkerReceived = true;
                 }
                 RNFetchBlobProgressConfig reportConfig = RNFetchBlobReq.getReportProgress(mTaskId);
-                if (reportConfig != null && contentLength() != 0 &&reportConfig.shouldReport(bytesDownloaded / contentLength())) {
-                    WritableMap args = Arguments.createMap();
-                    args.putString("taskId", mTaskId);
-                    args.putString("written", String.valueOf(bytesDownloaded));
-                    args.putString("total", String.valueOf(contentLength()));
-                    rctContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                            .emit(RNFetchBlobConst.EVENT_PROGRESS, args);
+
+                if (contentLength() != 0) {
+
+                    // For non-chunked download, progress is received / total
+                    // For chunked download, progress can be either 0 (started) or 1 (ended)
+                    float progress = (contentLength() != -1) ? bytesDownloaded / contentLength() : ( ( isEndMarkerReceived ) ? 1 : 0 );
+
+                    if (reportConfig != null && reportConfig.shouldReport(progress /* progress */)) {
+                        if (contentLength() != -1) {
+                            // For non-chunked downloads
+                            reportProgress(mTaskId, bytesDownloaded, contentLength());
+                        } else {
+                            // For chunked downloads
+                            if (!isEndMarkerReceived) {
+                                reportProgress(mTaskId, 0, contentLength());
+                            } else{
+                                reportProgress(mTaskId, bytesDownloaded, bytesDownloaded);
+                            }
+                        }
+                    }
+
                 }
+
                 return read;
             } catch(Exception ex) {
                 return -1;
             }
+        }
+
+        private void reportProgress(String taskId, long bytesDownloaded, long contentLength) {
+            WritableMap args = Arguments.createMap();
+            args.putString("taskId", taskId);
+            args.putString("written", String.valueOf(bytesDownloaded));
+            args.putString("total", String.valueOf(contentLength));
+            rctContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit(RNFetchBlobConst.EVENT_PROGRESS, args);
         }
 
         @Override


### PR DESCRIPTION
Here is the second attempt to solve the issue wkh237#264. Current version doesn't throw a promise rejection upon incomplete file download to storage directly, on android. I am providing a fix by comparing the bytes downloaded with the content length.

**Changes**

Added a method isDownloadComplete() that returns true only id download is complete. For non-chunked downloads, it compares with Content Length. For chunked, it looks for a end marker (which is an empty byte data as explained in https://tools.ietf.org/html/rfc7230#section-4.1). Progress for chunked transfer has also been improved. Earlier, the progress being reported was negative for chunked downloads (because contrantLength() returned -1). Now the progress is set to two state - 0 (Download started) and 1 (Download ended).

**Validation**

Tested on android. Throws RNFetchBlob failed. Download interrupted upon interruption for both the case.

Link for Non-chunked test file - https://file-examples.com/wp-content/uploads/2017/02/file-sample_1MB.docx
Link for chunked test file - http://anglesharp.azurewebsites.net/Chunked
