### PR TITLE
Fix #458 - Remove duped FLAG_ACTIVITY_NEW_TASK

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -121,8 +121,6 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                  // All the activity to be opened outside of an activity
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
-                // All the activity to be opened outside of an activity
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                 // Validate that the device can open the file
                 PackageManager pm = getCurrentActivity().getPackageManager();
                 if (intent.resolveActivity(pm) != null) {


### PR DESCRIPTION
Fixes #458 

Looks like https://github.com/joltup/rn-fetch-blob/pull/317 made it in here twice.
Removing the dupe.