### PR TITLE
[Android] Add uriForFile to get content Uri from specific path

### DIFF
--- a/android.js
+++ b/android.js
@@ -11,6 +11,13 @@ import {
 
 const RNFetchBlob:RNFetchBlobNative = NativeModules.RNFetchBlob
 
+function uriForFile(path: string) {
+  if (Platform.OS === 'android')
+    return RNFetchBlob.uriForFile(path);
+  else
+    return Promise.reject('RNFetchBlob.android.actionViewIntent only supports Android.')
+}
+
 /**
  * Send an intent to open the file.
  * @param  {string} path Path of the file to be open.
@@ -54,6 +61,7 @@ function getSDCardApplicationDir() {
 
 
 export default {
+  uriForFile,
   actionViewIntent,
   getContentIntent,
   addCompleteDownload,

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -106,6 +106,13 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void uriForFile(String path, Promise promise) {
+        Uri uriForFile = FileProvider.getUriForFile(getCurrentActivity(),
+                this.getReactApplicationContext().getPackageName() + ".provider", new File(path));
+        promise.resolve(uriForFile.toString());
+    }
+
+    @ReactMethod
     public void actionViewIntent(String path, String mime, final Promise promise) {
         try {
             Uri uriForFile = FileProvider.getUriForFile(getCurrentActivity(),

--- a/index.d.ts
+++ b/index.d.ts
@@ -453,6 +453,12 @@ export interface IOSApi {
 
 export interface AndroidApi {
     /**
+     * Get content uri for specific file
+     * @param path Path of the local file
+     */
+    uriForFile(path: string): Promise<string>;
+    
+    /**
      * When sending an ACTION_VIEW intent with given file path and MIME type, system will try to open an
      * App to handle the file. For example, open Gallery app to view an image, or install APK.
      * @param path Path of the file to be opened.


### PR DESCRIPTION
On Android, after downloading video, I would like to share it via facebook. But the path must be content uri to make it work. So, I added new method to get content uri from specific file path. 