### PR TITLE
Catching invalid file paths with exists()

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -665,10 +665,14 @@ class RNFetchBlobFS {
             }
         }
         else {
-            path = normalizePath(path);
-            boolean exist = new File(path).exists();
-            boolean isDir = new File(path).isDirectory();
-            callback.invoke(exist, isDir);
+            try {
+                path = normalizePath(path);
+                boolean exist = new File(path).exists();
+                boolean isDir = new File(path).isDirectory();
+                callback.invoke(exist, isDir);
+            } catch (NullPointerException e) {
+                callback.invoke(false, false);
+            }
         }
     }
 


### PR DESCRIPTION
Catching NullPointerException triggered from File when normalizePath returns null (ie data:image/png;base64,....)