### PR TITLE
(Android) Fix multi-byte UTF-8 issue : Translating the non english language data properly

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -514,11 +514,13 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                             String utf8 = new String(b);
                             callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_UTF8, utf8);
                         }
-                        // This usually mean the data is contains invalid unicode characters, it's
-                        // binary data
+                        // This usually mean the data is contains invalid unicode characters but still valid data,
+                        // it's binary data, so send it as a normal string
                         catch(CharacterCodingException ignored) {
+                            
                             if(responseFormat == ResponseFormat.UTF8) {
-                                callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_UTF8, "");
+                                String utf8 = new String(b);
+                                callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_UTF8, utf8);
                             }
                             else {
                                 callback.invoke(null, RNFetchBlobConst.RNFB_RESPONSE_BASE64, android.util.Base64.encodeToString(b, Base64.NO_WRAP));


### PR DESCRIPTION
Fixes #297 

### Purpose of the PR
We are having this issue for all our `Arabic` data received from the server as that data gets converted to some gibberish data after we use RNFetchBlob fetch as 

```
RNFetchBlob.fetch(method, url, { 'RNFB-Response' : 'utf8',  ...headers }, body )
```
The proposed changes fix the issue, and again we can see the Arabic content as supposed to be.

### How did I tested
- I did same change on my local library and tested on our APP, and that worked on actual device and emulator both.
- I read the related issues, and saw the reverted PR #353 as that fix had the missing `if/else`  condition which made the base64 crash, I added that check also in this PR.