### PR TITLE
Fix comment: default timeout from 30000ms to 60000ms

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function wrap(path:string):string {
  *                   activity takes place )
  *                   If it doesn't exist, the file is downloaded as usual
  *         @property {number} timeout
- *                   Request timeout in millionseconds, by default it's 30000ms.
+ *                   Request timeout in millionseconds, by default it's 60000ms.
  *
  * @return {function} This method returns a `fetch` method instance.
  */


### PR DESCRIPTION
There is a comment in index.js that the default timeout value is 30000ms.

https://github.com/joltup/rn-fetch-blob/blob/ffc372e6e7f64ac77404549489557133ff4475f4/index.js#L106-L107

But the actual value of this is 60000ms.

https://github.com/joltup/rn-fetch-blob/blob/ffc372e6e7f64ac77404549489557133ff4475f4/polyfill/XMLHttpRequest.js#L44

https://github.com/joltup/rn-fetch-blob/blob/ffc372e6e7f64ac77404549489557133ff4475f4/android/src/main/java/com/RNFetchBlob/RNFetchBlobConfig.java#L17