### PR TITLE
Check if addAndroidDownloads map has the notification key before consuming

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -160,7 +160,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
             if (options.addAndroidDownloads.getBoolean("useDownloadManager")) {
                 Uri uri = Uri.parse(url);
                 DownloadManager.Request req = new DownloadManager.Request(uri);
-                if(options.addAndroidDownloads.getBoolean("notification")) {
+                if(options.addAndroidDownloads.hasKey("notification") && options.addAndroidDownloads.getBoolean("notification")) {
                     req.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
                 } else {
                     req.setNotificationVisibility(DownloadManager.Request.VISIBILITY_HIDDEN);


### PR DESCRIPTION
Attempting to read the `notification` key without making sure it's within the addAndroidDownloads map causes a fatal crash. This code will ensure we safely check that the ReadableMap contains the key prior to consuming it.

```
com.facebook.react.bridge.NoSuchKeyException notification 
    ReadableNativeMap.java:3 com.facebook.react.bridge.ReadableNativeMap.getValue
    ReadableNativeMap.java:4 com.facebook.react.bridge.ReadableNativeMap.getValue
    ReadableNativeMap.java:1 com.facebook.react.bridge.ReadableNativeMap.getBoolean
    RNFetchBlobReq.java:5 com.RNFetchBlob.RNFetchBlobReq.run
    RNFetchBlob.java:1 com.RNFetchBlob.RNFetchBlob.fetchBlob
    Method.java:-2 java.lang.reflect.Method.invoke
    JavaMethodWrapper.java:18 com.facebook.react.bridge.JavaMethodWrapper.invoke
    JavaModuleWrapper.java:2 com.facebook.react.bridge.JavaModuleWrapper.invoke
    NativeRunnable.java:-2 com.facebook.react.bridge.queue.NativeRunnable.run
    Handler.java:873 android.os.Handler.handleCallback
    Handler.java:99 android.os.Handler.dispatchMessage
    MessageQueueThreadHandler.java:1 com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage
    Looper.java:214 android.os.Looper.loop
    MessageQueueThreadImpl.java:8 com.facebook.react.bridge.queue.MessageQueueThreadImpl$4.run
    Thread.java:764 java.lang.Thread.run
```