### PR TITLE
Use 'NSURLSessionUploadTask' when upload large file

### DIFF
--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -110,6 +110,7 @@ RCT_EXPORT_METHOD(fetchBlobForm:(NSDictionary *)options
                                                       bridge:self.bridge
                                                       taskId:taskId
                                                  withRequest:req
+                                                    filePath:nil
                                                     callback:callback];
         }
     }];
@@ -132,7 +133,7 @@ RCT_EXPORT_METHOD(fetchBlob:(NSDictionary *)options
                                      headers:headers
                                         body:body
                                   onComplete:^(NSURLRequest *req, long bodyLength)
-    {
+     {
         // something went wrong when building the request body
         if(req == nil)
         {
@@ -141,11 +142,20 @@ RCT_EXPORT_METHOD(fetchBlob:(NSDictionary *)options
         // send HTTP request
         else
         {
+            
+            NSString * fileName = nil;
+            // Post or put large file
+            if([body hasPrefix:FILE_PREFIX]) {
+                fileName = [body substringFromIndex:[FILE_PREFIX length]];
+                fileName = [RNFetchBlobFS getPathOfAsset:fileName];
+            }
+            
             [[RNFetchBlobNetwork sharedInstance] sendRequest:options
                                                contentLength:bodyLength
                                                       bridge:self.bridge
                                                       taskId:taskId
                                                  withRequest:req
+                                                    filePath:fileName
                                                     callback:callback];
         }
     }];

--- a/ios/RNFetchBlobNetwork.h
+++ b/ios/RNFetchBlobNetwork.h
@@ -20,31 +20,30 @@
 #import "RCTBridgeModule.h"
 #endif
 
-
-@interface RNFetchBlobNetwork : NSObject  <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
+@interface RNFetchBlobNetwork : NSObject <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
 
 @property(nonnull, nonatomic) NSOperationQueue *taskQueue;
-@property(nonnull, nonatomic) NSMapTable<NSString*, RNFetchBlobRequest*> * requestsTable;
-@property(nonnull, nonatomic) NSMutableDictionary<NSString*, RNFetchBlobProgress*> *rebindProgressDict;
-@property(nonnull, nonatomic) NSMutableDictionary<NSString*, RNFetchBlobProgress*> *rebindUploadProgressDict;
+@property(nonnull, nonatomic) NSMapTable<NSString *, RNFetchBlobRequest *> *requestsTable;
+@property(nonnull, nonatomic) NSMutableDictionary<NSString *, RNFetchBlobProgress *> *rebindProgressDict;
+@property(nonnull, nonatomic) NSMutableDictionary<NSString *, RNFetchBlobProgress *> *rebindUploadProgressDict;
 
-+ (RNFetchBlobNetwork* _Nullable)sharedInstance;
-+ (NSMutableDictionary  * _Nullable ) normalizeHeaders:(NSDictionary * _Nullable)headers;
-+ (void) emitExpiredTasks;
++ (RNFetchBlobNetwork *_Nullable)sharedInstance;
++ (NSMutableDictionary *_Nullable)normalizeHeaders:(NSDictionary *_Nullable)headers;
++ (void)emitExpiredTasks;
 
-- (nullable id) init;
-- (void) sendRequest:(NSDictionary  * _Nullable )options
-       contentLength:(long)contentLength
-              bridge:(RCTBridge * _Nullable)bridgeRef
-              taskId:(NSString * _Nullable)taskId
-         withRequest:(NSURLRequest * _Nullable)req
-            callback:(_Nullable RCTResponseSenderBlock) callback;
-- (void) cancelRequest:(NSString * _Nonnull)taskId;
-- (void) enableProgressReport:(NSString * _Nonnull) taskId config:(RNFetchBlobProgress * _Nullable)config;
-- (void) enableUploadProgress:(NSString * _Nonnull) taskId config:(RNFetchBlobProgress * _Nullable)config;
+- (nullable id)init;
+- (void)sendRequest:(NSDictionary *_Nullable)options
+      contentLength:(long)contentLength
+             bridge:(RCTBridge *_Nullable)bridgeRef
+             taskId:(NSString *_Nullable)taskId
+        withRequest:(NSURLRequest *_Nullable)req
+           filePath:(NSString *_Nullable)filePath
+           callback:(_Nullable RCTResponseSenderBlock)callback;
 
+- (void)cancelRequest:(NSString *_Nonnull)taskId;
+- (void)enableProgressReport:(NSString *_Nonnull)taskId config:(RNFetchBlobProgress *_Nullable)config;
+- (void)enableUploadProgress:(NSString *_Nonnull)taskId config:(RNFetchBlobProgress *_Nullable)config;
 
 @end
-
 
 #endif /* RNFetchBlobNetwork_h */

--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -71,12 +71,13 @@ static void initialize_tables() {
     return _sharedInstance;
 }
 
-- (void) sendRequest:(__weak NSDictionary  * _Nullable )options
-       contentLength:(long) contentLength
-              bridge:(RCTBridge * _Nullable)bridgeRef
-              taskId:(NSString * _Nullable)taskId
-         withRequest:(__weak NSURLRequest * _Nullable)req
-            callback:(_Nullable RCTResponseSenderBlock) callback
+- (void)sendRequest:(__weak NSDictionary  * _Nullable )options
+      contentLength:(long) contentLength
+             bridge:(RCTBridge * _Nullable)bridgeRef
+             taskId:(NSString * _Nullable)taskId
+        withRequest:(__weak NSURLRequest * _Nullable)req
+           filePath:(NSString * _Nullable)filePath
+           callback:(_Nullable RCTResponseSenderBlock) callback
 {
     RNFetchBlobRequest *request = [[RNFetchBlobRequest alloc] init];
     [request sendRequest:options
@@ -85,6 +86,7 @@ static void initialize_tables() {
                   taskId:taskId
              withRequest:req
       taskOperationQueue:self.taskQueue
+                filePath:filePath
                 callback:callback];
     
     @synchronized([RNFetchBlobNetwork class]) {

--- a/ios/RNFetchBlobReqBuilder.m
+++ b/ios/RNFetchBlobReqBuilder.m
@@ -103,8 +103,8 @@
         if([[method lowercaseString] isEqualToString:@"post"] || [[method lowercaseString] isEqualToString:@"put"] || [[method lowercaseString] isEqualToString:@"patch"]) {
             // generate octet-stream body
             if(body != nil) {
-                __block NSString * cType = [[self class] getHeaderIgnoreCases:@"content-type" fromHeaders:mheaders];
-                __block NSString * transferEncoding = [[self class] getHeaderIgnoreCases:@"transfer-encoding" fromHeaders:mheaders];
+                 NSString * cType = [[self class] getHeaderIgnoreCases:@"content-type" fromHeaders:mheaders];
+                
                 // when headers does not contain a key named "content-type" (case ignored), use default content type
                 if(cType == nil)
                 {
@@ -133,16 +133,6 @@
                         }];
                         
                         return;
-                    }
-                    size = [[[NSFileManager defaultManager] attributesOfItemAtPath:orgPath error:nil] fileSize];
-                    if(transferEncoding != nil && [[transferEncoding lowercaseString] isEqualToString:@"chunked"])
-                    {
-                        [request setHTTPBodyStream: [NSInputStream inputStreamWithFileAtPath:orgPath ]];
-                    }
-                    else
-                    {
-                        __block NSData * bodyBytes = [NSData dataWithContentsOfFile:orgPath ];
-                        [request setHTTPBody:bodyBytes];
                     }
                 }
                 // otherwise convert it as BASE64 data string

--- a/ios/RNFetchBlobRequest.h
+++ b/ios/RNFetchBlobRequest.h
@@ -21,27 +21,27 @@
 
 @interface RNFetchBlobRequest : NSObject <NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate>
 
-@property (nullable, nonatomic) NSString * taskId;
-@property (nonatomic) long long expectedBytes;
-@property (nonatomic) long long receivedBytes;
-@property (nonatomic) BOOL isServerPush;
-@property (nullable, nonatomic) NSMutableData * respData;
-@property (nullable, strong, nonatomic) RCTResponseSenderBlock callback;
-@property (nullable, nonatomic) RCTBridge * bridge;
-@property (nullable, nonatomic) NSDictionary * options;
-@property (nullable, nonatomic) NSError * error;
-@property (nullable, nonatomic) RNFetchBlobProgress *progressConfig;
-@property (nullable, nonatomic) RNFetchBlobProgress *uploadProgressConfig;
-@property (nullable, nonatomic, weak) NSURLSessionDataTask *task;
+@property(nullable, nonatomic) NSString *taskId;
+@property(nonatomic) long long expectedBytes;
+@property(nonatomic) long long receivedBytes;
+@property(nonatomic) BOOL isServerPush;
+@property(nullable, nonatomic) NSMutableData *respData;
+@property(nullable, strong, nonatomic) RCTResponseSenderBlock callback;
+@property(nullable, nonatomic) RCTBridge *bridge;
+@property(nullable, nonatomic) NSDictionary *options;
+@property(nullable, nonatomic) NSError *error;
+@property(nullable, nonatomic) RNFetchBlobProgress *progressConfig;
+@property(nullable, nonatomic) RNFetchBlobProgress *uploadProgressConfig;
+@property(nullable, nonatomic, weak) NSURLSessionDataTask *task;
 
-- (void) sendRequest:(NSDictionary  * _Nullable )options
-       contentLength:(long)contentLength
-              bridge:(RCTBridge * _Nullable)bridgeRef
-              taskId:(NSString * _Nullable)taskId
-         withRequest:(NSURLRequest * _Nullable)req
-  taskOperationQueue:(NSOperationQueue * _Nonnull)operationQueue
-            callback:(_Nullable RCTResponseSenderBlock) callback;
-
+- (void)sendRequest:(NSDictionary *_Nullable)options
+      contentLength:(long)contentLength
+             bridge:(RCTBridge *_Nullable)bridgeRef
+             taskId:(NSString *_Nullable)taskId
+        withRequest:(NSURLRequest *_Nullable)req
+ taskOperationQueue:(NSOperationQueue *_Nonnull)operationQueue
+           filePath:(NSString *_Nonnull)filePath
+           callback:(_Nullable RCTResponseSenderBlock)callback;
 @end
 
 #endif /* RNFetchBlobRequest_h */

--- a/ios/RNFetchBlobRequest.m
+++ b/ios/RNFetchBlobRequest.m
@@ -71,6 +71,7 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
               taskId:(NSString * _Nullable)taskId
          withRequest:(__weak NSURLRequest * _Nullable)req
   taskOperationQueue:(NSOperationQueue * _Nonnull)operationQueue
+            filePath:(NSString *)filePath
             callback:(_Nullable RCTResponseSenderBlock) callback
 {
     self.taskId = taskId;
@@ -161,7 +162,15 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
         respFile = NO;
     }
 
-    self.task = [session dataTaskWithRequest:req];
+    if (filePath != nil &&
+        ([req.HTTPMethod.lowercaseString isEqualToString:@"post"] ||
+                      [req.HTTPMethod.lowercaseString isEqualToString:@"put"]) ) {
+        self.task = [session uploadTaskWithRequest:req fromFile:[NSURL URLWithString:filePath]];
+
+    } else {
+        self.task = [session dataTaskWithRequest:req];
+        
+    }
     [self.task resume];
 
     // network status indicator


### PR DESCRIPTION
When upload the large file which is 400MB 

The file load action will make the memory increase to very high, some device may crashed.

```
NSData * bodyBytes = [NSData dataWithContentsOfFile:orgPath ];	// Will load all file into RAM
[request setHTTPBody:bodyBytes];
```
Resolve:

Use `NSURLSessionUploadTask` and setup the file path to upload file. Don't load the file into NSData as the Http-Body

```
 NSURLSessionUploadTask *task = [session uploadTaskWithRequest:req fromFile:[NSURL URLWithString:filePath]];
```