### PR TITLE
feat(ios): present open in menu

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -457,21 +457,21 @@ export interface IOSApi {
      * @param  {string} path Path of the file to be open.
      * @param  {string} scheme URI scheme that needs to support, optional
      */
-    presentOptionsMenu(path: string, scheme: string): void;
+    presentOptionsMenu(path: string, scheme?: string): void;
 
     /**
      * Displays a menu for opening the document using [UIDocumentInteractionController](https://developer.apple.com/reference/uikit/uidocumentinteractioncontroller).[presentOpenInMenu](https://developer.apple.com/documentation/uikit/uidocumentinteractioncontroller/1616807-presentopeninmenu)
      * @param  {string} path Path of the file to be open.
      * @param  {string} scheme URI scheme that needs to support, optional
      */
-    presentOpenInMenu(path: string, scheme: string): void;
+    presentOpenInMenu(path: string, scheme?: string): void;
 
     /**
      * Displays a full-screen preview of the target document using [UIDocumentInteractionController](https://developer.apple.com/reference/uikit/uidocumentinteractioncontroller).[presentPreview](https://developer.apple.com/documentation/uikit/uidocumentinteractioncontroller/1616828-presentpreview)
      * @param  {string} path Path of the file to be open.
      * @param  {string} scheme URI scheme that needs to support, optional
      */
-    presentPreview(path: string, scheme: string): void;
+    presentPreview(path: string, scheme?: string): void;
 }
 
 export interface AndroidDownloadOption {

--- a/index.d.ts
+++ b/index.d.ts
@@ -441,14 +441,37 @@ export interface IOSApi {
      * Open a file in {@link https://developer.apple.com/reference/uikit/uidocumentinteractioncontroller UIDocumentInteractionController},
      * this is the default document viewer of iOS, supports several kinds of files. On Android, there's an similar method {@link android.actionViewIntent}.
      * @param path This is a required field, the path to the document. The path should NOT contains any scheme prefix.
+     * @param  {string} scheme URI scheme that needs to support, optional
      */
-    previewDocument(path: string): void;
+    previewDocument(path: string, scheme?: string): void;
 
     /**
      * Show options menu for interact with the file.
      * @param path This is a required field, the path to the document. The path should NOT contains any scheme prefix.
+     * @param  {string} scheme URI scheme that needs to support, optional
      */
-    openDocument(path: string): void;
+    openDocument(path: string, scheme?: string): void;
+
+    /**
+     * Displays an options menu using [UIDocumentInteractionController](https://developer.apple.com/reference/uikit/uidocumentinteractioncontroller).[presentOptionsMenu](https://developer.apple.com/documentation/uikit/uidocumentinteractioncontroller/1616814-presentoptionsmenu)
+     * @param  {string} path Path of the file to be open.
+     * @param  {string} scheme URI scheme that needs to support, optional
+     */
+    presentOptionsMenu(path: string, scheme: string): void;
+
+    /**
+     * Displays a menu for opening the document using [UIDocumentInteractionController](https://developer.apple.com/reference/uikit/uidocumentinteractioncontroller).[presentOpenInMenu](https://developer.apple.com/documentation/uikit/uidocumentinteractioncontroller/1616807-presentopeninmenu)
+     * @param  {string} path Path of the file to be open.
+     * @param  {string} scheme URI scheme that needs to support, optional
+     */
+    presentOpenInMenu(path: string, scheme: string): void;
+
+    /**
+     * Displays a full-screen preview of the target document using [UIDocumentInteractionController](https://developer.apple.com/reference/uikit/uidocumentinteractioncontroller).[presentPreview](https://developer.apple.com/documentation/uikit/uidocumentinteractioncontroller/1616828-presentpreview)
+     * @param  {string} path Path of the file to be open.
+     * @param  {string} scheme URI scheme that needs to support, optional
+     */
+    presentPreview(path: string, scheme: string): void;
 }
 
 export interface AndroidDownloadOption {
@@ -475,7 +498,7 @@ export interface AndroidDownloadOption {
     /**
      * Boolean value that determines if notification will be displayed.
      */
-    showNotification: boolean 
+    showNotification: boolean
 }
 
 export interface AndroidApi {

--- a/ios.js
+++ b/ios.js
@@ -2,39 +2,44 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import {
-  NativeModules,
-  DeviceEventEmitter,
-  Platform,
-  NativeAppEventEmitter,
-} from 'react-native'
+import { NativeModules, Platform } from "react-native";
 
-const RNFetchBlob:RNFetchBlobNative = NativeModules.RNFetchBlob
+const RNFetchBlob: RNFetchBlobNative = NativeModules.RNFetchBlob;
 
 /**
- * Open a file using UIDocumentInteractionController
+ * Displays an options menu using UIDocumentInteractionController.presentOptionsMenu
  * @param  {string} path Path of the file to be open.
  * @param  {string} scheme URI scheme that needs to support, optional
  * @return {Promise}
  */
-function previewDocument(path:string, scheme:string) {
-  if(Platform.OS === 'ios')
-    return RNFetchBlob.previewDocument('file://' + path, scheme)
-  else
-    return Promise.reject('RNFetchBlob.openDocument only supports IOS.')
+function presentOptionsMenu(path: string, scheme: string) {
+  if (Platform.OS === "ios")
+    return RNFetchBlob.presentOptionsMenu("file://" + path, scheme);
+  else return Promise.reject("RNFetchBlob.openDocument only supports IOS.");
 }
 
 /**
- * Preview a file using UIDocumentInteractionController
+ * Displays a menu for opening the document using UIDocumentInteractionController.presentOpenInMenu
  * @param  {string} path Path of the file to be open.
  * @param  {string} scheme URI scheme that needs to support, optional
  * @return {Promise}
  */
-function openDocument(path:string, scheme:string) {
-  if(Platform.OS === 'ios')
-    return RNFetchBlob.openDocument('file://' + path, scheme)
-  else
-    return Promise.reject('RNFetchBlob.previewDocument only supports IOS.')
+function presentOpenInMenu(path: string, scheme: string) {
+  if (Platform.OS === "ios")
+    return RNFetchBlob.presentOpenInMenu("file://" + path, scheme);
+  else return Promise.reject("RNFetchBlob.openDocument only supports IOS.");
+}
+
+/**
+ * Displays a full-screen preview of the target document using UIDocumentInteractionController.presentPreview
+ * @param  {string} path Path of the file to be open.
+ * @param  {string} scheme URI scheme that needs to support, optional
+ * @return {Promise}
+ */
+function presentPreview(path: string, scheme: string) {
+  if (Platform.OS === "ios")
+    return RNFetchBlob.presentPreview("file://" + path, scheme);
+  else return Promise.reject("RNFetchBlob.previewDocument only supports IOS.");
 }
 
 /**
@@ -43,12 +48,15 @@ function openDocument(path:string, scheme:string) {
  * @param  {string} url URL of the resource, only file URL is supported
  * @return {Promise}
  */
-function excludeFromBackupKey(path:string) {
-  return RNFetchBlob.excludeFromBackupKey('file://' + path);
+function excludeFromBackupKey(path: string) {
+  return RNFetchBlob.excludeFromBackupKey("file://" + path);
 }
 
 export default {
-  openDocument,
-  previewDocument,
+  presentPreview,
+  openDocument: presentPreview, // legacy alias
+  presentOptionsMenu,
+  previewDocument: presentOptionsMenu, // legacy alias
+  presentOpenInMenu,
   excludeFromBackupKey
-}
+};

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -573,7 +573,7 @@ RCT_EXPORT_METHOD(slice:(NSString *)src dest:(NSString *)dest start:(nonnull NSN
     [RNFetchBlobFS slice:src dest:dest start:start end:end encode:@"" resolver:resolve rejecter:reject];
 }
 
-RCT_EXPORT_METHOD(previewDocument:(NSString*)uri scheme:(NSString *)scheme resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(presentOptionsMenu:(NSString*)uri scheme:(NSString *)scheme resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSString * utf8uri = [uri stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     NSURL * url = [[NSURL alloc] initWithString:utf8uri];
@@ -592,9 +592,27 @@ RCT_EXPORT_METHOD(previewDocument:(NSString*)uri scheme:(NSString *)scheme resol
     }
 }
 
+RCT_EXPORT_METHOD(presentOpenInMenu:(NSString*)uri scheme:(NSString *)scheme resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+    NSString * utf8uri = [uri stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    NSURL * url = [[NSURL alloc] initWithString:utf8uri];
+    documentController = [UIDocumentInteractionController interactionControllerWithURL:url];
+    UIViewController *rootCtrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+    documentController.delegate = self;
+    if(scheme == nil || [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString:scheme]]) {
+      CGRect rect = CGRectMake(0.0, 0.0, 0.0, 0.0);
+      dispatch_sync(dispatch_get_main_queue(), ^{
+          [documentController  presentOpenInMenuFromRect:rect inView:rootCtrl.view animated:YES];
+      });
+        resolve(@[[NSNull null]]);
+    } else {
+        reject(@"EINVAL", @"scheme is not supported", nil);
+    }
+}
+
 # pragma mark - open file with UIDocumentInteractionController and delegate
 
-RCT_EXPORT_METHOD(openDocument:(NSString*)uri scheme:(NSString *)scheme resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(presentPreview:(NSString*)uri scheme:(NSString *)scheme resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     NSString * utf8uri = [uri stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
     NSURL * url = [[NSURL alloc] initWithString:utf8uri];


### PR DESCRIPTION
For our project we need `openInMenu` native functionality rather than `optionsMenu` which currently this module provides via `previewDocument`. This PR adds it.

When I started to investigate the problem, I found that method name mapping js <-> native is very confusing. So, because JS api is platform-specific anyway, I decided to provide native method names in addition to current methods.

P.S. After I committed files I realized that my IDE spoiled the code style and created some diff noise, because there is no editorconfig/prettier/eslint/whatever in this project. If you insist, I can fix this manually, but I suggest you to add some styling config and format everything.