### PR TITLE
[Android] Promise resolve and reject for actionViewIntent

### DIFF
--- a/README.md
+++ b/README.md
@@ -586,14 +586,22 @@ RNFetchBlob.config({
   })
   .fetch('GET', `http://www.example.com/awesome.apk`)
   .then((res) => {
-      android.actionViewIntent(res.path(), 'application/vnd.android.package-archive')
+      android.actionViewIntent(res.path(), 'application/vnd.android.package-archive').then(() => {
+        console.log('File opened')
+      }).catch(e => {
+        console.warn('Unable to open file', e);
+      })
   })
 ```
 
 Or show an image in image viewer
 
 ```js
-      android.actionViewIntent(PATH_OF_IMG, 'image/png')
+      android.actionViewIntent(PATH_OF_IMG, 'image/png').then(() => {
+        console.log('File opened')
+      }).catch(e => {
+        console.warn('Unable to open file', e);
+      })
 ```
 
 ## File System

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -111,10 +111,10 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
             Uri uriForFile = FileProvider.getUriForFile(getCurrentActivity(),
                     this.getReactApplicationContext().getPackageName() + ".provider", new File(path));
 
+            Intent intent = new Intent(Intent.ACTION_VIEW);
             if (Build.VERSION.SDK_INT >= 24) {
                 // Create the intent with data and type
-                Intent intent = new Intent(Intent.ACTION_VIEW)
-                        .setDataAndType(uriForFile, mime);
+                intent.setDataAndType(uriForFile, mime);
 
                 // Set flag to give temporary permission to external app to use FileProvider
                 intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
@@ -123,15 +123,16 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
 
                 // Validate that the device can open the file
                 PackageManager pm = getCurrentActivity().getPackageManager();
-                if (intent.resolveActivity(pm) != null) {
-                    this.getReactApplicationContext().startActivity(intent);
-                }
-
             } else {
-                Intent intent = new Intent(Intent.ACTION_VIEW)
-                        .setDataAndType(Uri.parse("file://" + path), mime).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                intent.setDataAndType(Uri.parse("file://" + path), mime).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            }
 
+            PackageManager pm = getCurrentActivity().getPackageManager();
+            if (intent.resolveActivity(pm) != null) {
                 this.getReactApplicationContext().startActivity(intent);
+                promise.resolve(true);
+            } else {
+                promise.reject("ENOAPP", "No app installed for " + mime);
             }
             ActionViewVisible = true;
 

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -598,7 +598,11 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 } catch (ClassCastException ex) {
                     // unexpected response type
                     if (responseBody != null) {
-                        callback.invoke("Unexpected FileStorage response file: " + responseBody.string(), null);
+                        try {
+                            callback.invoke("Unexpected FileStorage response file: " + responseBody.string(), null);
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
                     } else {
                         callback.invoke("Unexpected FileStorage response with no file.", null);
                     }


### PR DESCRIPTION
Now actionViewIntent() will resolving on successful activity launch for viewing file. If no package was founded for viewing file - promise will reject with error `No app installed for <MIME_TYPE>`.  