### PR TITLE
fix(android): fixes unreported IOException

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -598,7 +598,11 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 } catch (ClassCastException ex) {
                     // unexpected response type
                     if (responseBody != null) {
-                        callback.invoke("Unexpected FileStorage response file: " + responseBody.string(), null);
+                        String bodyStr = "";
+                        try {
+                            bodyStr = responseBody.string();
+                        } catch (Exception ignored) {/*ignore */}
+                        callback.invoke("Unexpected FileStorage response file: " + bodyStr, null);
                     } else {
                         callback.invoke("Unexpected FileStorage response with no file.", null);
                     }


### PR DESCRIPTION
Line 601 causes me build error: 
```
rn-fetch-blob/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java:601: error: unreported exception IOException; must be caught or declared to be thrown
                        callback.invoke("Unexpected FileStorage response file: " + responseBody.string(), null);
                                                                                                      ^
1 error
```

This is a naive fix. OkHttp docs say that `responseBody.string()`:

> This method loads entire response body into memory. If the response body is very large this may trigger an OutOfMemoryError. Prefer to stream the response body if this is a possibility for your response.

Is it good idea to load entire response body into error message and send it over bridge?