### PR TITLE
feat(android): add optional chooser to actionViewIntent

### DIFF
--- a/android.js
+++ b/android.js
@@ -2,29 +2,25 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import {
-  NativeModules,
-  DeviceEventEmitter,
-  Platform,
-  NativeAppEventEmitter,
-} from 'react-native'
+import { NativeModules, Platform } from 'react-native'
 
-const RNFetchBlob:RNFetchBlobNative = NativeModules.RNFetchBlob
+const RNFetchBlob = NativeModules.RNFetchBlob
 
 /**
  * Send an intent to open the file.
  * @param  {string} path Path of the file to be open.
  * @param  {string} mime MIME type string
+ * @param  {string} title for chooser, if not set the chooser won't be displayed (see https://developer.android.com/reference/android/content/Intent.html#createChooser(android.content.Intent,%20java.lang.CharSequence))
  * @return {Promise}
  */
-function actionViewIntent(path:string, mime:string = 'text/plain') {
+function actionViewIntent(path, mime, chooserTitle) {
   if(Platform.OS === 'android')
-    return RNFetchBlob.actionViewIntent(path, mime)
+    return RNFetchBlob.actionViewIntent(path, mime, chooserTitle)
   else
     return Promise.reject('RNFetchBlob.android.actionViewIntent only supports Android.')
 }
 
-function getContentIntent(mime:string) {
+function getContentIntent(mime) {
   if(Platform.OS === 'android')
     return RNFetchBlob.getContentIntent(mime)
   else

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -27,6 +27,7 @@ import com.facebook.react.modules.network.OkHttpClientProvider;
 import okhttp3.OkHttpClient;
 import okhttp3.JavaNetCookieJar;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -106,7 +107,7 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void actionViewIntent(String path, String mime, final Promise promise) {
+    public void actionViewIntent(String path, String mime, @Nullable String chooserTitle, final Promise promise) {
         try {
             Uri uriForFile = FileProvider.getUriForFile(getCurrentActivity(),
                     this.getReactApplicationContext().getPackageName() + ".provider", new File(path));
@@ -115,6 +116,9 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 // Create the intent with data and type
                 Intent intent = new Intent(Intent.ACTION_VIEW)
                         .setDataAndType(uriForFile, mime);
+                if (chooserTitle != null) {
+                    intent = Intent.createChooser(intent, chooserTitle);
+                }
 
                 // Set flag to give temporary permission to external app to use FileProvider
                 intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
@@ -130,6 +134,9 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
             } else {
                 Intent intent = new Intent(Intent.ACTION_VIEW)
                         .setDataAndType(Uri.parse("file://" + path), mime).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                if (chooserTitle != null) {
+                    intent = Intent.createChooser(intent, chooserTitle);
+                }
 
                 this.getReactApplicationContext().startActivity(intent);
             }

--- a/index.d.ts
+++ b/index.d.ts
@@ -484,8 +484,9 @@ export interface AndroidApi {
      * App to handle the file. For example, open Gallery app to view an image, or install APK.
      * @param path Path of the file to be opened.
      * @param mime Basically system will open an app according to this MIME type.
+     * @param chooserTitle title for chooser, if not set the chooser won't be displayed (see [Android docs](https://developer.android.com/reference/android/content/Intent.html#createChooser(android.content.Intent,%20java.lang.CharSequence)))
      */
-    actionViewIntent(path: string, mime: string): Promise<any>;
+    actionViewIntent(path: string, mime: string, chooserTitle?: string): Promise<any>;
 
     /**
      * 


### PR DESCRIPTION
This PR solves the following problem: on most android devices and emulators `actionViewIntent` opens a dialog where you can choose one of installed apps to open the file. Hovewer, on Huawei devices, it opens some default EMUI app. By adding optional chooser I was able to get to select app dialog on Huawei devices too.