### PR TITLE
added exception with msf scheme from android 10 for document uri

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/Utils/PathResolver.java
+++ b/android/src/main/java/com/RNFetchBlob/Utils/PathResolver.java
@@ -47,7 +47,7 @@ public class PathResolver {
                         return path;
                     }
                     
-                    String docId = null;
+                    Long docId = null;
                     //Since Android 10, uri can start with msf scheme like "msf:12345"
                     if (id != null && id.startsWith("msf:")) {
                         final String[] split = id.split(":");

--- a/android/src/main/java/com/RNFetchBlob/Utils/PathResolver.java
+++ b/android/src/main/java/com/RNFetchBlob/Utils/PathResolver.java
@@ -46,9 +46,18 @@ public class PathResolver {
                         String path = rawuri.getPath();
                         return path;
                     }
+                    
+                    String docId = null;
+                    //Since Android 10, uri can start with msf scheme like "msf:12345"
+                    if (id != null && id.startsWith("msf:")) {
+                        final String[] split = id.split(":");
+                        docId = Long.valueOf(split[1]);
+                    } else {
+                        docId = Long.valueOf(id);
+                    }
+                    
                     final Uri contentUri = ContentUris.withAppendedId(
-                            Uri.parse("content://downloads/public_downloads"), Long.valueOf(id));
-
+                            Uri.parse("content://downloads/public_downloads"), docId);
                     return getDataColumn(context, contentUri, null, null);
                 }
                 catch (Exception ex) {


### PR DESCRIPTION
Crashes detected in PathResolver using API29 with new type of uri "content://com.android.providers.downloads.documents/document/msf:24" resulting on id like "msf:24" instead of number. I don't know if my patch is the best solution but could fix temporarily the next error:
`java.lang.NumberFormatException in Long.java:594 java.lang.Long.parseLong`