### PR TITLE
tcp multipath working on iOS

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobConfig.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobConfig.java
@@ -11,6 +11,7 @@ class RNFetchBlobConfig {
     public ReadableMap addAndroidDownloads;
     public Boolean trusty;
     public Boolean wifiOnly = false;
+    public Boolean multipath = false;
     public String key;
     public String mime;
     public Boolean auto;
@@ -28,6 +29,7 @@ class RNFetchBlobConfig {
         this.appendExt = options.hasKey("appendExt") ? options.getString("appendExt") : "";
         this.trusty = options.hasKey("trusty") ? options.getBoolean("trusty") : false;
         this.wifiOnly = options.hasKey("wifiOnly") ? options.getBoolean("wifiOnly") : false;
+        this.multipath = options.hasKey("multipath") ? options.getBoolean("multipath") : false;
         if(options.hasKey("addAndroidDownloads")) {
             this.addAndroidDownloads = options.getMap("addAndroidDownloads");
         }

--- a/index.d.ts
+++ b/index.d.ts
@@ -475,7 +475,7 @@ export interface AndroidDownloadOption {
     /**
      * Boolean value that determines if notification will be displayed.
      */
-    showNotification: boolean 
+    showNotification: boolean
 }
 
 export interface AndroidApi {
@@ -488,7 +488,7 @@ export interface AndroidApi {
     actionViewIntent(path: string, mime: string): Promise<any>;
 
     /**
-     * 
+     *
      * This method brings up OS default file picker and resolves a file URI when the user selected a file.
      * However, it does not resolve or reject when user dismiss the file picker via pressing hardware back button,
      * but you can still handle this behavior via AppState.
@@ -607,6 +607,11 @@ export interface RNFetchBlobConfig {
      * file will stored in App's own root folder with file name template RNFetchBlob_tmp${timestamp}.
      */
     fileCache?: boolean;
+
+    /**
+     * Set this property to true to allow multipath tcp connection (wifi assist)
+     */
+    multipath?: boolean;
 
     /**
      * Set this property to change temp file extension that created by fetch response data.

--- a/index.js
+++ b/index.js
@@ -111,6 +111,8 @@ function wrap(path:string):string {
  *                   Trust all certificates
  *         @property {boolean} wifiOnly
  *                   Only do requests through WiFi. Android SDK 21 or above only.
+ *         @property {boolean} multipath
+ *                   Allow wifi assist
  *
  * @return {function} This method returns a `fetch` method instance.
  */

--- a/index.js.flow
+++ b/index.js.flow
@@ -165,6 +165,7 @@ export type RNFetchBlobConfig = {
   timeout?: number,
   trusty?: boolean,
   wifiOnly?: boolean,
+  multipath?: boolean,
   followRedirect?: boolean
 };
 export type RNFetchBlobResponseInfo = {

--- a/ios/RNFetchBlobConst.h
+++ b/ios/RNFetchBlobConst.h
@@ -33,6 +33,7 @@ extern NSString *const CONFIG_FILE_PATH;
 extern NSString *const CONFIG_FILE_EXT;
 extern NSString *const CONFIG_TRUSTY;
 extern NSString *const CONFIG_WIFI_ONLY;
+extern NSString *const CONFIG_MULTIPATH;
 extern NSString *const CONFIG_INDICATOR;
 extern NSString *const CONFIG_KEY;
 extern NSString *const CONFIG_EXTRA_BLOB_CTYPE;

--- a/ios/RNFetchBlobConst.m
+++ b/ios/RNFetchBlobConst.m
@@ -17,6 +17,7 @@ NSString *const CONFIG_FILE_PATH = @"path";
 NSString *const CONFIG_FILE_EXT = @"appendExt";
 NSString *const CONFIG_TRUSTY = @"trusty";
 NSString *const CONFIG_WIFI_ONLY = @"wifiOnly";
+NSString *const CONFIG_MULTIPATH = @"multipath";
 NSString *const CONFIG_INDICATOR = @"indicator";
 NSString *const CONFIG_KEY = @"key";
 NSString *const CONFIG_EXTRA_BLOB_CTYPE = @"binaryContentTypes";

--- a/ios/RNFetchBlobRequest.m
+++ b/ios/RNFetchBlobRequest.m
@@ -126,6 +126,12 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
 
     if([options valueForKey:CONFIG_WIFI_ONLY] != nil && ![options[CONFIG_WIFI_ONLY] boolValue]){
         [defaultConfigObject setAllowsCellularAccess:NO];
+    } else if([options valueForKey:CONFIG_MULTIPATH] != nil && [options[CONFIG_MULTIPATH] boolValue]){
+        if (@available(iOS 11.0, *)) {
+            [defaultConfigObject setMultipathServiceType:NSURLSessionMultipathServiceTypeInteractive];
+        } else {
+            // Fallback on earlier versions
+        }
     }
 
     defaultConfigObject.HTTPMaximumConnectionsPerHost = 10;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rn-fetch-blob",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A module provides upload, download, and files access API. Supports file stream read/write for process large files.",
   "main": "index.js",
   "scripts": {

--- a/types.js
+++ b/types.js
@@ -8,7 +8,8 @@ type RNFetchBlobConfig = {
   indicator : bool,
   followRedirect : bool,
   trusty : bool,
-  wifiOnly : bool
+  wifiOnly : bool,
+  multipath: bool
 };
 
 type RNFetchBlobNative = {


### PR DESCRIPTION
only working on iOS, add a multipath option to allow multipath queries on iOS > 11,
phone will automatically determine if it should use cellular or wifi data. (used for an application where the phone need to be connected to a wifi network with no internet access)