### PR TITLE
Handle configs for each task individually rather than enumerating through all configs

### DIFF
--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -89,22 +89,24 @@ static void initialize_tables() {
     
     @synchronized([RNFetchBlobNetwork class]) {
         [self.requestsTable setObject:request forKey:taskId];
-        [self checkProgressConfig];
+        [self checkProgressConfigForTask:taskId];
     }
 }
 
-- (void) checkProgressConfig {
+- (void) checkProgressConfigForTask:(NSString *)taskId {
     //reconfig progress
-    [self.rebindProgressDict enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, RNFetchBlobProgress * _Nonnull config, BOOL * _Nonnull stop) {
-        [self enableProgressReport:key config:config];
-    }];
-    [self.rebindProgressDict removeAllObjects];
+    RNFetchBlobProgress *downloadConfig = self.rebindProgressDict[taskId];
+    if (downloadConfig != nil) {
+        [self enableProgressReport:taskId config:downloadConfig];
+        [self.rebindProgressDict removeObjectForKey:taskId];
+    }
     
     //reconfig uploadProgress
-    [self.rebindUploadProgressDict enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, RNFetchBlobProgress * _Nonnull config, BOOL * _Nonnull stop) {
-        [self enableUploadProgress:key config:config];
-    }];
-    [self.rebindUploadProgressDict removeAllObjects];
+    RNFetchBlobProgress *uploadConfig = self.rebindUploadProgressDict[taskId];
+    if (uploadConfig != nil) {
+        [self enableUploadProgress:taskId config:uploadConfig];
+        [self.rebindUploadProgressDict removeObjectForKey:taskId];
+    }
 }
 
 - (void) enableProgressReport:(NSString *) taskId config:(RNFetchBlobProgress *)config


### PR DESCRIPTION
When downloading/uploading multiple blobs, the progress is only reported back for one task. This is because when a URLSession (iOS) is started, it uses the config based on a task id and, when it does this, it attempts to enable progress reporting for all other tasks, after which it removes the tasks from the dictionary of tasks to be enabled. Because of a race condition, this actually makes it so that only the first task for which progress reporting is enabled actually reports progress. This PR fixes that issue by handling this process on a case-by-case basis and only removes pending tasks after they have been moved to the dictionary of enabled tasks.