### PR TITLE
Removed android:label="@string/app_name"

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
     <!-- Required to read and write the expansion files on shared storage -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
-    <application android:label="@string/app_name">
+    <application>
 
         <provider
             android:name="com.RNFetchBlob.Utils.FileProvider"


### PR DESCRIPTION
Remove app label, as it serves no purpose here. If it's not the same as in the main manifest.xml, the build will throw a manifest merger error. This can happen, if you have variable there, from gradle.properties (added through app/build/gradle)