### PR TITLE
Add .npmignore and move glob to devDependencies

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,91 @@
+# JS
+node_modules
+yarn.lock
+
+# Project files
+CONTRIBUTORS.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+
+# Config files
+.babelrc
+babel.config.js
+.editorconfig
+.eslintrc
+.flowconfig
+.watchmanconfig
+jsconfig.json
+.npmrc
+.gitattributes
+.circleci
+*.coverage.json
+.opensource
+.circleci
+.eslintignore
+codecov.yml
+
+# Scripts
+scripts/
+
+# Example
+img/
+example/
+app.json
+
+# Android
+android/*/build/
+android/gradlew
+android/build
+android/gradlew.bat
+android/gradle/
+android/com_crashlytics_export_strings.xml
+android/local.properties
+android/.gradle/
+android/.signing/
+android/.idea/gradle.xml
+android/.idea/libraries/
+android/.idea/workspace.xml
+android/.idea/tasks.xml
+android/.idea/.name
+android/.idea/compiler.xml
+android/.idea/copyright/profiles_settings.xml
+android/.idea/encodings.xml
+android/.idea/misc.xml
+android/.idea/modules.xml
+android/.idea/scopes/scope_settings.xml
+android/.idea/vcs.xml
+android/*.iml
+android/.settings
+
+# iOS
+ios/*.xcodeproj/xcuserdata
+*.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+*.xcuserstate
+project.xcworkspace/
+xcuserdata/
+ios/build/
+
+# Misc
+.DS_Store
+.DS_Store?
+*.DS_Store
+coverage.android.json
+coverage.ios.json
+coverage
+npm-debug.log
+.github
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.dbandroid/gradle
+docs
+.idea
+tests/
+bin/test.js
+codorials
+.vscode
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "base-64": "0.1.0",
-    "glob": "7.0.6"
+    "glob": "^7.1.6"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
This diff fixes two issues:
* Remove the `img` folder (2.4 MiB) from the npm distribution.
* Updated the glob dependency to use `^` so that it isn't locked to one specific version.
