### PR TITLE
Prevent crashes on Android devices

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -600,7 +600,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                     if (responseBody != null) {
                         String responseBodyString = null;
                         try {
-                            responseBodyString = responseBody.string();
+                            responseBodyString = resp.peekBody(Long.MAX_VALUE).string();
                         } catch(IOException exception) {
                             exception.printStackTrace();
                         }

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -600,7 +600,11 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                     if (responseBody != null) {
                         String responseBodyString = null;
                         try {
-                            responseBodyString = resp.peekBody(Long.MAX_VALUE).string();
+                            try {
+                                responseBodyString = responseBody.string();
+                            } catch(IllegalStateException exception) {
+                                exception.printStackTrace();
+                            }
                         } catch(IOException exception) {
                             exception.printStackTrace();
                         }


### PR DESCRIPTION
With the latest version of `rn-fetch-blob` we detected several related crashe due to a `IllegalStateException` which was not being managed. This PR adds a try catch block to prevent apps crashing for this reason.