### PR TITLE
Reject android intent promise when there is no app available for the file type

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -126,7 +126,7 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 if (intent.resolveActivity(pm) != null) {
                     this.getReactApplicationContext().startActivity(intent);
                 } else {
-                    promise.reject("ERESOLVEACTIVITY");
+                    promise.reject("EINVAL", "File is not supported");
                 }
 
             } else {

--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -125,6 +125,8 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
                 PackageManager pm = getCurrentActivity().getPackageManager();
                 if (intent.resolveActivity(pm) != null) {
                     this.getReactApplicationContext().startActivity(intent);
+                } else {
+                    promise.reject("ERESOLVEACTIVITY");
                 }
 
             } else {


### PR DESCRIPTION
Currently, if the device doesn't have any app to open a specific type of file, the intent is not displayed and there is no feedback for the user.
Rejecting the promise with the "EINVAL" code (same used for iOS if I'm not wrong) make it possible to catch this on the javascript side and allows it to send an alert/toast to the user explaining what just happened.