### PR TITLE
Fix an issue with non "image" mime types downloading on android

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -762,11 +762,9 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                             return;
                         }
                         String contentUri = c.getString(c.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI));
-                        if ( contentUri != null &&
-                                options.addAndroidDownloads.hasKey("mime") &&
-                                options.addAndroidDownloads.getString("mime").contains("image")) {
+                        if ( contentUri != null ) {
                             Uri uri = Uri.parse(contentUri);
-                            Cursor cursor = appCtx.getContentResolver().query(uri, new String[]{android.provider.MediaStore.Images.ImageColumns.DATA}, null, null, null);
+                            Cursor cursor = appCtx.getContentResolver().query(uri, new String[]{android.provider.MediaStore.Files.FileColumns.DATA}, null, null, null);
                             // use default destination of DownloadManager
                             if (cursor != null) {
                                 cursor.moveToFirst();


### PR DESCRIPTION
Addresses https://github.com/joltup/rn-fetch-blob/issues/214 and https://github.com/wkh237/react-native-fetch-blob/issues/606

- `filePath` wasn't being set for non image based mime types, causing download manager to throw an error, even though the file downloaded successfully