### PR TITLE
check if buffer data and content exists before trying get data from source

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -600,7 +600,11 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                     if (responseBody != null) {
                         String responseBodyString = null;
                         try {
-                            responseBodyString = responseBody.string();
+                            boolean isBufferDataExists = responseBody.source().buffer().size() > 0;
+                            boolean isContentExists = responseBody.contentLength() > 0;
+                            if (isBufferDataExists && isContentExists) {
+                                responseBodyString = responseBody.string();
+                            }
                         } catch(IOException exception) {
                             exception.printStackTrace();
                         }


### PR DESCRIPTION
Fixes the consequences from  #530 ( #490 and #630 )
