### PR TITLE
[Android] Fix actionViewIntent for OS <= 6

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlob.java
@@ -111,28 +111,23 @@ public class RNFetchBlob extends ReactContextBaseJavaModule {
             Uri uriForFile = FileProvider.getUriForFile(getCurrentActivity(),
                     this.getReactApplicationContext().getPackageName() + ".provider", new File(path));
 
-            if (Build.VERSION.SDK_INT >= 24) {
-                // Create the intent with data and type
-                Intent intent = new Intent(Intent.ACTION_VIEW)
-                        .setDataAndType(uriForFile, mime);
+            // Create the intent with data and type
+            Intent intent = new Intent(Intent.ACTION_VIEW)
+                    .setDataAndType(uriForFile, mime);
 
-                // Set flag to give temporary permission to external app to use FileProvider
-                intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                 // All the activity to be opened outside of an activity
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            // Set flag to give temporary permission to external app to use FileProvider
+            intent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                // All the activity to be opened outside of an activity
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
-                // Validate that the device can open the file
-                PackageManager pm = getCurrentActivity().getPackageManager();
-                if (intent.resolveActivity(pm) != null) {
-                    this.getReactApplicationContext().startActivity(intent);
-                }
-
-            } else {
-                Intent intent = new Intent(Intent.ACTION_VIEW)
-                        .setDataAndType(Uri.parse("file://" + path), mime).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-
+            // Validate that the device can open the file
+            PackageManager pm = getCurrentActivity().getPackageManager();
+            if (intent.resolveActivity(pm) != null) {
                 this.getReactApplicationContext().startActivity(intent);
+            } else {
+                promise.reject("EUNSPECIFIED", "Cannot open the URL.");
             }
+
             ActionViewVisible = true;
 
             final LifecycleEventListener listener = new LifecycleEventListener() {


### PR DESCRIPTION
actionViewIntent does not work for SDK < 24

It seems that this part of the code was introduced when migrating to Android file providers: https://github.com/wkh237/react-native-fetch-blob/issues/358 
The blog post about it: https://inthecheesefactory.com/blog/how-to-share-access-to-file-with-fileprovider-on-android-nougat/en  says that from the moment we set targetSdkVersion to something superior to 24, we need to pass through a file provider: "This behavior will happen only when you change your app's targetSdkVersion to 24 or above".

I imagine that the dev that implemented it thinking (with good will) that he needed to separate the two flows depending on the device Android SDK version at the runtime, but now that the default config is set as 28 in the build.gralde, we should remove this logic. File providers are meant to work even for Android SDK < 24, it all depends on the target version set when we build.

Also, I take some part of the PR for [Android] Promise resolve and reject for actionViewIntent (https://github.com/joltup/rn-fetch-blob/pull/535) as it is very useful to have a promise rejection when the intent is not resolved (kudos to MikeChugunov)