### PR TITLE
Resolve #722 "iOS Release network requests not completing"

### DIFF
--- a/ios/RNFetchBlobRequest.m
+++ b/ios/RNFetchBlobRequest.m
@@ -161,8 +161,9 @@ typedef NS_ENUM(NSUInteger, ResponseFormat) {
         respFile = NO;
     }
 
-    self.task = [session dataTaskWithRequest:req];
-    [self.task resume];
+    NSURLSessionDataTask *task = [session dataTaskWithRequest:req];
+    [task resume];
+    self.task = task;
 
     // network status indicator
     if ([[options objectForKey:CONFIG_INDICATOR] boolValue]) {


### PR DESCRIPTION
Providing the third, less intrusive, solution as discussed in [#722](https://github.com/joltup/rn-fetch-blob/issues/722) and refers to making a minor modification that proved to work for us locally and not result in the `self.task` object being deallocated in Release.

```objc
NSURLSessionDataTask *task = [session dataTaskWithRequest:req];
[task resume];
self.task = task;
```

P.S. Not sure why I can't link issues to this PR.