### PR TITLE
fix normalizing file:// paths with special characters

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobFS.java
@@ -1138,9 +1138,6 @@ class RNFetchBlobFS {
             return null;
         if(!path.matches("\\w+\\:.*"))
             return path;
-        if(path.startsWith("file://")) {
-            return path.replace("file://", "");
-        }
 
         Uri uri = Uri.parse(path);
         if(path.startsWith(RNFetchBlobConst.FILE_PREFIX_BUNDLE_ASSET)) {


### PR DESCRIPTION
File uris with space and other special characters are not correctly normalized. The fix is to removing 3 lines of code on `normalizePath()` because the correct normalization code already exists in `PathResolver.getRealPathFromURI()`.

Example input: `file:///storage/emulated/0/Foo%20Bar`
Correct output: `/storage/emulated/0/Foo Bar`.
Current (wrong) output: `/storage/emulated/0/Foo%20Bar`.
