### PR TITLE
Fix addAndroidDownloads for paths containing %

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -177,7 +177,7 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                     req.setDescription(options.addAndroidDownloads.getString("description"));
                 }
                 if(options.addAndroidDownloads.hasKey("path")) {
-                    req.setDestinationUri(Uri.parse("file://" + options.addAndroidDownloads.getString("path")));
+                    req.setDestinationUri(Uri.fromFile(new File(options.addAndroidDownloads.getString("path"))));
                 }
                 // #391 Add MIME type to the request
                 if(options.addAndroidDownloads.hasKey("mime")) {


### PR DESCRIPTION
Before this fix, specifying a path in the addAndroidDownloads option containing a "%" character would result in an error when downloading.

This is because in one place in the code when reading the path value, we assume the value is URI encoded, whereas in another place, we assume it is not URI encoded.

I updated the code to consistently assume the path is _not_ URI encoded.

With this fix, downloading now works correctly for us for paths containing a "%" character when we specify the path unencoded.