### PR TITLE
Allow to get the applicationSupport path on iOS

### DIFF
--- a/fs.js
+++ b/fs.js
@@ -23,7 +23,8 @@ const dirs = {
   SDCardDir: RNFetchBlob.SDCardDir, // Depracated
   SDCardApplicationDir: RNFetchBlob.SDCardApplicationDir, // Deprecated
   MainBundleDir : RNFetchBlob.MainBundleDir,
-  LibraryDir : RNFetchBlob.LibraryDir
+  LibraryDir : RNFetchBlob.LibraryDir,
+  ApplicationSupportDir: RNFetchBlob.ApplicationSupportDir
 }
 
 function addCode(code: string, error: Error): Error {

--- a/ios/RNFetchBlob/RNFetchBlob.m
+++ b/ios/RNFetchBlob/RNFetchBlob.m
@@ -76,6 +76,7 @@ RCT_EXPORT_MODULE();
              @"MovieDir" : [RNFetchBlobFS getMovieDir],
              @"MusicDir" : [RNFetchBlobFS getMusicDir],
              @"PictureDir" : [RNFetchBlobFS getPictureDir],
+             @"ApplicationSupportDir" : [RNFetchBlobFS getApplicationSupportDir],
              };
 }
 

--- a/ios/RNFetchBlobFS.h
+++ b/ios/RNFetchBlobFS.h
@@ -54,6 +54,7 @@
 + (NSString *) getMovieDir;
 + (NSString *) getMusicDir;
 + (NSString *) getPictureDir;
++ (NSString *) getApplicationSupportDir;
 + (NSString *) getTempPath;
 + (NSString *) getTempPath:(NSString*)taskId withExtension:(NSString *)ext;
 + (NSString *) getPathOfAsset:(NSString *)assetURI;

--- a/ios/RNFetchBlobFS.m
+++ b/ios/RNFetchBlobFS.m
@@ -124,6 +124,10 @@ NSMutableDictionary *fileStreams = nil;
     return [NSSearchPathForDirectoriesInDomains(NSPicturesDirectory, NSUserDomainMask, YES) firstObject];
 }
 
++ (NSString *) getApplicationSupportDir {
+    return [NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) firstObject];
+}
+
 + (NSString *) getTempPath {
 
     return NSTemporaryDirectory();


### PR DESCRIPTION
There was no way to store or read files in the application support directory