### PR TITLE
wrap supports iOS 'file://' path that's common for react-native files

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,8 +78,10 @@ if(!RNFetchBlob || !RNFetchBlob.fetchBlobForm || !RNFetchBlob.fetchBlob) {
 }
 
 function wrap(path:string):string {
-  const prefix = path.startsWith('content://') ? 'RNFetchBlob-content://' : 'RNFetchBlob-file://'
-  return prefix + path
+  if (path.startsWith('file://') || path.startsWith('content://')){
+    return 'RNFetchBlob-'+path;
+  }
+  return 'RNFetchBlob-file://' + path
 }
 
 /**


### PR DESCRIPTION
support uris / file paths that start with file://


tested on iphone 15 and works as expected

react-native files are usually presented in a string that starts with "file://" so .. wrap function should support that out of the box.