### PR TITLE
Reduce concurrent operation count from 10 to 1

### DIFF
--- a/ios/RNFetchBlobNetwork.m
+++ b/ios/RNFetchBlobNetwork.m
@@ -52,7 +52,7 @@ static void initialize_tables() {
         
         self.taskQueue = [[NSOperationQueue alloc] init];
         self.taskQueue.qualityOfService = NSQualityOfServiceUtility;
-        self.taskQueue.maxConcurrentOperationCount = 10;
+        self.taskQueue.maxConcurrentOperationCount = 1;
         self.rebindProgressDict = [NSMutableDictionary dictionary];
         self.rebindUploadProgressDict = [NSMutableDictionary dictionary];
     }


### PR DESCRIPTION
> The queue should be a serial queue, in order to ensure the correct ordering of callbacks.

https://developer.apple.com/documentation/foundation/nsurlsession/1411597-sessionwithconfiguration