### PR TITLE
Update RNFetchBlobReq.java

### DIFF
--- a/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
+++ b/android/src/main/java/com/RNFetchBlob/RNFetchBlobReq.java
@@ -196,7 +196,11 @@ public class RNFetchBlobReq extends BroadcastReceiver implements Runnable {
                 DownloadManager dm = (DownloadManager) appCtx.getSystemService(Context.DOWNLOAD_SERVICE);
                 downloadManagerId = dm.enqueue(req);
                 androidDownloadManagerTaskTable.put(taskId, Long.valueOf(downloadManagerId));
-                appCtx.registerReceiver(this, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+                if (Build.VERSION.SDK_INT >= 34 && appCtx.getApplicationInfo().targetSdkVersion >= 34) {
+                    appCtx.registerReceiver(this, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE), Context.RECEIVER_EXPORTED);
+                }else{
+                    appCtx.registerReceiver(this, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+                }
                 return;
             }
 


### PR DESCRIPTION
Register BroadcastReceiver for ACTION_DOWNLOAD_COMPLETE with version-based handling

- Added conditional logic to register the BroadcastReceiver for `DownloadManager.ACTION_DOWNLOAD_COMPLETE`.
- For Android SDK 34 and above (and target SDK 34 and above), included the `Context.RECEIVER_EXPORTED` flag to comply with new permissions requirements.
- For Android versions below SDK 34, registered the receiver without the `RECEIVER_EXPORTED` flag to maintain compatibility.


<img width="1033" alt="Screenshot 2024-08-09 at 15 23 52" src="https://github.com/user-attachments/assets/4107981f-8337-4a69-8fe0-f3a946cef0d9">
